### PR TITLE
Add reuse values option

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `disable_webhooks` - (Optional) Prevent hooks from running.
 * `force_update` - (Optional) Force resource update through delete/recreate if needed.
 * `recreate_pods` - (Optional) On update performs pods restart for the resource if applicable.
+* `reuse_values` - (Optional) Reuse values from preveus revision when upgrading a release. Same as `--reuse-values` flag in Helm CLI. Default is false.
 * `reuse` - (Optional) Instructs Tiller to re-use an existing name. Default is true.
 
 The `set` block supports:

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -116,6 +116,12 @@ func resourceRelease() *schema.Resource {
 				Default:     false,
 				Description: "Prevent hooks from running.",
 			},
+			"reuse_values": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Reuse values when upgrading the release.",
+				Default:     false,
+			},
 			"force_update": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -328,6 +334,7 @@ func resourceReleaseUpdate(d *schema.ResourceData, meta interface{}) error {
 		helm.UpgradeForce(d.Get("force_update").(bool)),
 		helm.UpgradeDisableHooks(d.Get("disable_webhooks").(bool)),
 		helm.UpgradeTimeout(int64(d.Get("timeout").(int))),
+		helm.ReuseValues(d.Get("reuse_values").(bool)),
 		helm.UpgradeWait(true),
 	}
 


### PR DESCRIPTION
Add reuse values option for release update. Same as `--reuse-values` flag from `helm upgrade`.

Useful when release values can be modifies from outside Terraform configs.

We use [update-config](https://github.com/burdiyan/helm-update-config) to update image tag for deployment, and this is done outside Terraform configs.