### PR TITLE
[Feature] Added multiple values files support for release

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,9 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 resource "helm_release" "example" {
   name = "my_redis"
   chart = "redis"
+  values = [
+    "${file("values.yaml")}"
+  ]
 }
 ```
 
@@ -23,7 +26,7 @@ The following arguments are supported:
 * `chart` - (Required) Chart name to be installed.
 * `devel` - (Optional) Use chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored.
 * `version` - (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-* `values` - (Optional) Values in raw yaml file to pass to helm.
+* `values` - (Optional) List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options.
 * `set` - (Optional) Value block with custom values to be merge with the values.yaml.
 * `namespace` - (Optional) Namespace to install the release into.
 * `verify` - (Optional) Verify the package before installing it.
@@ -55,7 +58,7 @@ The `metadata` block supports:
 * `revision` - Version is an int32 which represents the version of the release.
 * `status` - Status of the release.
 * `version` - A SemVer 2 conformant version string of the chart.
-
+* `values` - The compounded values from `values` and `set`
 
 ## Import
 

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -187,6 +187,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return NewMeta(d)
 }
 
+// Meta is the meta information structure for the provider
 type Meta struct {
 	Settings         *helm_env.EnvSettings
 	TLSConfig        *tls.Config
@@ -201,6 +202,7 @@ type Meta struct {
 	sync.Mutex
 }
 
+// NewMeta will construct a new Meta from the provided ResourceData
 func NewMeta(d *schema.ResourceData) (*Meta, error) {
 	m := &Meta{data: d}
 	m.buildSettings(m.data)
@@ -328,6 +330,7 @@ func getK8sConfig(d *schema.ResourceData) (clientcmd.ClientConfig, error) {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides), nil
 }
 
+// GetHelmClient will return a new Helm client
 func (m *Meta) GetHelmClient() (helm.Interface, error) {
 	if err := m.initialize(); err != nil {
 		return nil, err

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/helm/pkg/strvals"
 )
 
+// ErrReleaseNotFound is the error when a Helm release is not found
 var ErrReleaseNotFound = errors.New("release not found")
 
 func resourceRelease() *schema.Resource {
@@ -195,7 +196,7 @@ func prepareTillerForNewRelease(d *schema.ResourceData, c helm.Interface, name s
 
 		switch r.Info.Status.GetCode() {
 		case release.Status_DEPLOYED:
-			return setIdAndMetadataFromRelease(d, r)
+			return setIDAndMetadataFromRelease(d, r)
 		case release.Status_FAILED:
 			// delete and recreate it
 			debug("release %s status is FAILED deleting it", name)
@@ -266,7 +267,7 @@ func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return setIdAndMetadataFromRelease(d, res.Release)
+	return setIDAndMetadataFromRelease(d, res.Release)
 }
 
 func resourceReleaseRead(d *schema.ResourceData, meta interface{}) error {
@@ -283,10 +284,10 @@ func resourceReleaseRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return setIdAndMetadataFromRelease(d, r)
+	return setIDAndMetadataFromRelease(d, r)
 }
 
-func setIdAndMetadataFromRelease(d *schema.ResourceData, r *release.Release) error {
+func setIDAndMetadataFromRelease(d *schema.ResourceData, r *release.Release) error {
 	d.SetId(r.Name)
 
 	return d.Set("metadata", []map[string]interface{}{{
@@ -332,7 +333,7 @@ func resourceReleaseUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return setIdAndMetadataFromRelease(d, res.Release)
+	return setIDAndMetadataFromRelease(d, res.Release)
 }
 
 func resourceReleaseDelete(d *schema.ResourceData, meta interface{}) error {

--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/helm/pkg/repo"
 )
 
+// ErrRepositoryNotFound is the error when a Helm repository is not found
 var ErrRepositoryNotFound = errors.New("repository not found")
 
 func resourceRepository() *schema.Resource {
@@ -102,7 +103,7 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return setIdAndMetadataFromRepository(d, r)
+	return setIDAndMetadataFromRepository(d, r)
 }
 
 func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
@@ -118,7 +119,7 @@ func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func setIdAndMetadataFromRepository(d *schema.ResourceData, r *repo.Entry) error {
+func setIDAndMetadataFromRepository(d *schema.ResourceData, r *repo.Entry) error {
 	d.SetId(r.Name)
 	return d.Set("metadata", []map[string]interface{}{{
 		"name": r.Name,


### PR DESCRIPTION
This PR intends to add support for ~~external~~ multiple value "files".
As it stands right now, the only way to use yaml values is to embed the values in the the terraform file.
With this PR, we can ~~reference external~~ use multiple files mimicking the `helm install -f <file>` functionality.

The file are specified in a list and will, as with Helm, be concatenated in order which makes value override possible. The order of resolution is:

1. The terraform `values` content merged in order
3. The `set` values 

Usage is:
```
values = [ "foo: bar", "${file("values.yaml")}" ]
```
~~Detection of changes in the file content is done by storing a `md5` hash of the content as validating with the current local file. If it does not match, the release is flagged to be updated.~~

**Note**: This is an API breaking change.




