### PR TITLE
[Bug fix] Handle list of empty string being converted to list of nils

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -474,13 +474,15 @@ func getValues(d *schema.ResourceData) ([]byte, error) {
 	base := map[string]interface{}{}
 
 	for _, raw := range d.Get("values").([]interface{}) {
-		values := raw.(string)
-		if values != "" {
-			currentMap := map[string]interface{}{}
-			if err := yaml.Unmarshal([]byte(values), &currentMap); err != nil {
-				return nil, err
+		if raw != nil {
+			values := raw.(string)
+			if values != "" {
+				currentMap := map[string]interface{}{}
+				if err := yaml.Unmarshal([]byte(values), &currentMap); err != nil {
+					return nil, fmt.Errorf("---> %v %s", err, values)
+				}
+				base = mergeValues(base, currentMap)
 			}
-			base = mergeValues(base, currentMap)
 		}
 	}
 

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -86,6 +86,23 @@ func TestAccResourceRelease_update(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_emptyValuesList(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHelmReleaseDestroy,
+		Steps: []resource.TestStep{{
+			Config: testAccHelmReleaseConfigValues(testReleaseName, testNamespace, testReleaseName, "0.6.2", []string{""}),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{}\n"),
+			),
+		},
+		},
+	})
+}
+
 func TestAccResourceRelease_updateValues(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
@@ -123,7 +140,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
 			),
 		}, {
-			Config: testAccHelmReleaseConfigValues(testReleaseName, testNamespace, testReleaseName, "0.6.2", []string{"foo: bar", "foo:baz"}),
+			Config: testAccHelmReleaseConfigValues(testReleaseName, testNamespace, testReleaseName, "0.6.2", []string{"foo: bar", "foo: baz"}),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
@@ -238,7 +255,7 @@ func testAccHelmReleaseConfigValues(resource, ns, name, version string, values [
 			namespace = %q
   			chart     = "stable/mariadb"
 			version   = %q
-			values = [ %q ]
+			values = [ %s ]
 		}
 	`, resource, name, ns, version, strings.Join(vals, ","))
 }


### PR DESCRIPTION
Given
```
resource "helm_release" "resource" {
  name      = "name"
  namespace = "namespace"
  chart     = "stable/mariadb"
  version   = "0.6.2"
    values = [ "" ]
}
```
Terraform will return a list which contains `nil` and not empty string.
This PR fixes the issue.

