### PR TITLE
Added feature to support bearer token as kubernetes authentication

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ The `kubernetes` block supports:
 * `host` - (Optional) The hostname (in form of URI) of Kubernetes master. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_USER`.
 * `password` - (Optional) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_PASSWORD`.
+* `token` - (Optional) The bearer token to use for authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_BEARER_TOKEN`.
 * `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. Can be sourced from `KUBE_INSECURE`.
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. Can be sourced from `KUBE_CLIENT_CERT_DATA`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -138,6 +138,12 @@ func kubernetesResource() *schema.Resource {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_PASSWORD", ""),
 				Description: "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_PASSWORD`.",
 			},
+			"token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_BEARER_TOKEN", ""),
+				Description: "The bearer token to use for authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_BEARER_TOKEN`.",
+			},
 			"insecure": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -261,6 +267,9 @@ func (m *Meta) buildK8sClient(d *schema.ResourceData) error {
 	}
 	if v, ok := k8sGetOk(d, "password"); ok {
 		cfg.Password = v.(string)
+	}
+	if v, ok := k8sGetOk(d, "token"); ok {
+		cfg.BearerToken = v.(string)
 	}
 	if v, ok := k8sGetOk(d, "insecure"); ok {
 		cfg.Insecure = v.(bool)


### PR DESCRIPTION
This PR intends to add support for bearer token authentication as stated in the [API credentials](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-set-credentials-em-)


