### PR TITLE
fixes issue/64: Add helms set-string option (set_string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ resource "helm_release" "my_database" {
         name = "mariadbPassword"
         value = "qux"
     }
+
+    set_string {
+        name = "image.tags"
+        value = "registry\\.io/terraform-provider-helm\\,example\\.io/terraform-provider-helm"
+    }
 }
 ```
 


### PR DESCRIPTION
Allows using `set_string` the same way as `set` which translates into helm's `set-string` and allows using characters like commas and periods.

Usage:

```
    set_string {
        name = "image.tags"
        value = "registry\\.io/terraform-provider-helm\\,example\\.io/terraform-provider-helm"
    }
```