### PR TITLE
Allow disabling the Tiller installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Terraform Provider for Helm [![Build Status](https://travis-ci.org/mcuadros/terr
 
 This is a [Helm](https://github.com/kubernetes/helm) provider for [Terraform](https://www.terraform.io/).
 
-The provider manage the installed [Charts](https://github.com/kubernetes/charts) in your Kubernetes cluster, in the same way of Helm does, through Terraform.
+The provider manages the installed [Charts](https://github.com/kubernetes/charts) in your Kubernetes cluster, in the same way of Helm does, through Terraform. It will also install Tiller automatically if it is not already present.
 
 Contents
 --------
@@ -20,7 +20,7 @@ Installation
 
 ### Requirements
 
-*terraform-provider-helm* is based on [Terraform](golang.org), this means that you need
+*terraform-provider-helm* is based on [Terraform](https://www.terraform.io), this means that you need
 
 
 - [Terraform](https://www.terraform.io/downloads.html) >=0.10.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,8 @@ The following arguments are supported:
 * `host` - (Required) Set an alternative Tiller host. The format is host:port. Can be sourced from `HELM_HOST`.
 * `home` - (Required) Set an alternative location for Helm files. By default, these are stored in '$HOME/.helm'. Can be sourced from `HELM_HOME`.
 * `namespace` - (Optional) Set an alternative Tiller namespace.
-* `tiller_image` - (Optional) Tiller image to install. If Tiller is not already installed.
+* `install_tiller` - (Optional) Install Tiller if it is not already installed.
+* `tiller_image` - (Optional) Tiller image to install.
 * `service_account` - (Optional) Service account to install Tiller with.
 * `debug` - (Optional)
 * `plugins_disable` - (Optional) Disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -52,11 +52,17 @@ func Provider() terraform.ResourceProvider {
 				Default:     tiller_env.DefaultTillerNamespace,
 				Description: "Set an alternative Tiller namespace.",
 			},
+			"install_tiller": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Install Tiller if it is not already installed.",
+			},
 			"tiller_image": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "gcr.io/kubernetes-helm/tiller:v2.9.0",
-				Description: "Tiller image to install. If Tiller is not already installed.",
+				Description: "Tiller image to install.",
 			},
 			"service_account": {
 				Type:        schema.TypeString,
@@ -372,6 +378,10 @@ func (m *Meta) initialize() error {
 }
 
 func (m *Meta) installTillerIfNeeded(d *schema.ResourceData) error {
+	if !d.Get("install_tiller").(bool) {
+		return nil
+	}
+
 	o := &installer.Options{}
 	o.Namespace = d.Get("namespace").(string)
 	o.ImageSpec = d.Get("tiller_image").(string)


### PR DESCRIPTION
Thanks for your work on this provider.

Given some of the security implications of Tiller, we'd prefer to be able to manage the installation ourselves. This PR adds an `install_tiller` parameter that can be set to `false` in order to prevent the provider from installing Tiller. The provider will still install Tiller by default, but this gives users the ability to opt out of that behaviour.