### PR TITLE
Update example to use a valid helm release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You should have a local configured copy of kubectl.
 
 ```hcl
 resource "helm_release" "my_database" {
-    name      = "my_datasase"
+    name      = "my-database"
     chart     = "stable/mariadb"
 
     set {


### PR DESCRIPTION
Attempting to test with this example fails because underscores are not
allowed in Kubernetes resource names.

```
* helm_release.my_database: rpc error: code = Unknown desc = release my_datasase failed: Secret "my_datasase-mariadb" is invalid: metadata.name: Invalid value: "my_datasase-mariadb": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```