### PR TITLE
Compile provider with static binaries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -72,7 +72,7 @@ packages:
 		for arch in $(PKG_ARCH); do \
 			mkdir -p $(BUILD_PATH)/$(PROVIDER)_$${os}_$${arch} && \
 			cd $(BASE_PATH) && \
-			GOOS=$${os} GOARCH=$${arch} go build -o $(BUILD_PATH)/$(PROVIDER)_$${os}_$${arch}/$(PROVIDER)_$(VERSION) . && \
+			CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} go build -o $(BUILD_PATH)/$(PROVIDER)_$${os}_$${arch}/$(PROVIDER)_$(VERSION) . && \
 			cd $(BUILD_PATH) && \
 			tar -cvzf $(BUILD_PATH)/$(PROVIDER)_$(BRANCH)_$${os}_$${arch}.tar.gz $(PROVIDER)_$${os}_$${arch}/; \
 		done; \


### PR DESCRIPTION
By default Go will compile dynamic binaries if possible. When compiling
from linux this means that Go will produce a dynamically linked binary.
This binary is not compatible with the official terraform docker images
from https://hub.docker.com/r/hashicorp/terraform/

```
❯ file terraform-provider-helm
terraform-provider-helm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=b443dd4fbff2d459f2bd4e2c966c3759d71a9f8a, not stripped
```