### PR TITLE
Statically compile provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ install:
   # See: https://github.com/golang/go/issues/12933
   - bash scripts/gogetcookie.sh
   - go get github.com/kardianos/govendor
+  
+env:
+  - CGO_ENABLED=0
 
 script:
   - make test


### PR DESCRIPTION
The official docker image for terraform is based on alpine linux, which doesn't have glibc installed.  So we need a statically compiled version.