### PR TITLE
Always update local healm repositories when reading resources

### DIFF
--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -113,6 +113,11 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	m := meta.(*Meta)
 
+	err := resourceRepositoryCreate(d, m)
+	if err != nil {
+		return err
+	}
+
 	r, err := getRepository(d, m)
 	if err != nil {
 		return err


### PR DESCRIPTION
The local repository is only created when `terraform apply` is run. This makes impossible for someone on a different machine to run a `terraform plan` since the repository will be missing.

In general, local config resources should be consistently applied as needed since their state are not persisted on the infrastructure. That said, I'm not sure if this is something that was brought up in the past or not.

Cheers!