### PR TITLE
Fix recursion caused by auto insert of repo

### DIFF
--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -19,6 +19,7 @@ func resourceRepository() *schema.Resource {
 		Create: resourceRepositoryCreate,
 		Read:   resourceRepositoryRead,
 		Delete: resourceRepositoryDelete,
+		Exists: resourceRepositoryExists,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -113,11 +114,6 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	m := meta.(*Meta)
 
-	err := resourceRepositoryCreate(d, m)
-	if err != nil {
-		return err
-	}
-
 	r, err := getRepository(d, m)
 	if err != nil {
 		return err
@@ -137,6 +133,15 @@ func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
 	debug("%q has been removed from your repositories\n", name)
 	d.SetId("")
 	return nil
+}
+
+func resourceRepositoryExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	err := resourceRepositoryCreate(d, meta)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 func setIDAndMetadataFromRepository(d *schema.ResourceData, r *repo.Entry) error {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/divoxx/terraform-provider-helm/helm"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-helm/helm"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/divoxx/terraform-provider-helm/helm"
 	"github.com/hashicorp/terraform/plugin"
+	"github.com/terraform-providers/terraform-provider-helm/helm"
 )
 
 func main() {


### PR DESCRIPTION
My previous change on 36428fcffb9355a16db4af7d601d0b52f379b3d0 is causing a recursion between the read and create methods of the provider.

This uses the Exists hook in order to create the resource when necessary without causing the recursion.