### PR TITLE
Revert "Always update local healm repositories when reading resources"

### DIFF
--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -113,11 +113,6 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	m := meta.(*Meta)
 
-	err := resourceRepositoryCreate(d, m)
-	if err != nil {
-		return err
-	}
-
 	r, err := getRepository(d, m)
 	if err != nil {
 		return err


### PR DESCRIPTION
Reverts terraform-providers/terraform-provider-helm#128

It causes a recursion between the read and create methods of the provider as described in #137 

