### PR TITLE
Bump Go version to 1.10.4 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 - docker
 language: go
 go:
-- 1.8.1
+- 1.10.4
 
 install:
 # This script is used by the Travis build to install a cookie for
@@ -27,3 +27,4 @@ branches:
 matrix:
   fast_finish: true
   allow_failures:
+  - go: tip


### PR DESCRIPTION
This aligns the Go version in Travis to the one used for releases.

@meyskens @rporres @terraform-providers/ecosystem 