### PR TITLE
Parameterize automountServiceAccountToken for tiller pod

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -70,6 +70,12 @@ func Provider() terraform.ResourceProvider {
 				Default:     "default",
 				Description: "Service account to install Tiller with.",
 			},
+			"automount_service_account_token": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Auto-mount the given service account to tiller.",
+			},
 			"override": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -398,6 +404,7 @@ func (m *Meta) installTillerIfNeeded(d *schema.ResourceData) error {
 	o.Namespace = d.Get("namespace").(string)
 	o.ImageSpec = d.Get("tiller_image").(string)
 	o.ServiceAccount = d.Get("service_account").(string)
+	o.AutoMountServiceAccountToken = d.Get("automount_service_account_token").(bool)
 	o.MaxHistory = d.Get("max_history").(int)
 
 	for _, rule := range d.Get("override").([]interface{}) {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -78,6 +78,7 @@ The following arguments are supported:
 * `install_tiller` - (Optional) Install Tiller if it is not already installed.
 * `tiller_image` - (Optional) Tiller image to install.
 * `service_account` - (Optional) Service account to install Tiller with.
+* `automount_service_account_token` - (Optional) Auto-mount the given service account to tiller.
 * `debug` - (Optional)
 * `plugins_disable` - (Optional) Disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
 * `enable_tls` - (Optional) Enables TLS communications with the Tiller.


### PR DESCRIPTION
This matches (and creates a parameter for) the CLI behavior.