### PR TITLE
Add manifest attribute

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -166,6 +166,11 @@ func resourceRelease() *schema.Resource {
 				Default:     true,
 				Description: "Will wait until all resources are in a ready state before marking the release as successful.",
 			},
+			"manifest": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The string representation of the rendered template.",
+			},
 			"metadata": {
 				Type:        schema.TypeSet,
 				Computed:    true,
@@ -339,6 +344,7 @@ func setIDAndMetadataFromRelease(d *schema.ResourceData, r *release.Release) err
 	d.SetId(r.Name)
 	d.Set("version", r.Chart.Metadata.Version)
 	d.Set("namespace", r.Namespace)
+	d.Set("manifest", r.Manifest)
 
 	return d.Set("metadata", []map[string]interface{}{{
 		"name":      r.Name,

--- a/website/docs/release.html.markdown
+++ b/website/docs/release.html.markdown
@@ -57,6 +57,7 @@ The `set` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `release` - The string representation of the rendered template.
 * `metadata` - Block status of the deployed release.
 
 The `metadata` block supports:

--- a/website/docs/release.html.markdown
+++ b/website/docs/release.html.markdown
@@ -57,7 +57,7 @@ The `set` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `release` - The string representation of the rendered template.
+* `manifest` - The string representation of the rendered template.
 * `metadata` - Block status of the deployed release.
 
 The `metadata` block supports:


### PR DESCRIPTION
This is a first step to implement #79.
Next step would be to refresh the manifest launching a dry-run so that we can have a clean output of what will change just like using the helm diff plugin