### PR TITLE
Fix when Helm provider ignores FAILED release state

### DIFF
--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -213,12 +213,12 @@ func TestAccResourceRelease_repository_url(t *testing.T) {
 func TestAccResourceRelease_updateAfterFail(t *testing.T) {
 	malformed := `
 	resource "helm_release" "test" {
-	  name        = "malformed"
-	  chart       = "stable/nginx-ingress"
-	  set {
-	      name = "controller.podAnnotations.\"prometheus\\.io/scrape\""
-	      value = "true"
-	  }
+		name        = "malformed"
+		chart       = "stable/nginx-ingress"
+		set {
+			name = "controller.name"
+			value = "invalid-$%!-character-for-k8s-label"
+		}
 	}
 	`
 

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -419,10 +419,10 @@ func testAccHelmReleaseConfigRepository(ns, name string) string {
 		}
 
 		resource "helm_release" "test" {
- 			name       = %q
+			name       = %q
 			namespace  = %q
 			repository = "${helm_repository.stable_repo.metadata.0.name}"
-  			chart      = "telegraf"
+			chart      = "coredns"
 		}
 	`, name, ns)
 }
@@ -433,7 +433,7 @@ func testAccHelmReleaseConfigRepositoryURL(ns, name string) string {
 			name       = %q
 			namespace  = %q
 			repository = "https://kubernetes-charts.storage.googleapis.com"
-			chart      = "telegraf"
+			chart      = "coredns"
 		}
 	`, name, ns)
 }

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -32,7 +32,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.name", "test-basic"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", testNamespace),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.chart", "mariadb"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
 			),
@@ -41,7 +41,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}},
 	})
@@ -81,14 +81,14 @@ func TestAccResourceRelease_update(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigBasic(testResourceName, testNamespace, "test-update", "0.6.3"),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.3"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}},
 	})
@@ -104,7 +104,7 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{}\n"),
 			),
 		}},
@@ -121,7 +121,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
 			),
 		}, {
@@ -130,7 +130,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: baz\n"),
 			),
 		}},
@@ -148,7 +148,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
 			),
 		}, {
@@ -158,7 +158,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: baz\n"),
 			),
 		}},
@@ -166,20 +166,21 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 }
 
 func TestAccResourceRelease_repository(t *testing.T) {
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigRepository(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigRepository(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 			),
 		}},
@@ -193,7 +194,7 @@ func TestAccResourceRelease_repository_url(t *testing.T) {
 			Config: testAccHelmReleaseConfigRepositoryURL(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "version"),
 			),
@@ -201,7 +202,7 @@ func TestAccResourceRelease_repository_url(t *testing.T) {
 			Config: testAccHelmReleaseConfigRepositoryURL(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "version"),
 			),
@@ -233,7 +234,7 @@ func TestAccResourceRelease_updateAfterFail(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.3"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}},
 	})
@@ -270,7 +271,7 @@ func TestAccResourceRelease_updateVersionFromRelease(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "version", "0.6.2"),
 			),
 		}, {
@@ -294,7 +295,7 @@ func TestAccResourceRelease_updateVersionFromRelease(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.3"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "version", "0.6.3"),
 			),
 		}},

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -100,7 +100,7 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 		CheckDestroy: testAccCheckHelmReleaseDestroy,
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigValues(
-				testResourceName, testNamespace, "test-empty-values-list", []string{""},
+				testResourceName, testNamespace, "test-empty-values-list", "stable/kibana", []string{""},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
@@ -117,7 +117,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 		CheckDestroy: testAccCheckHelmReleaseDestroy,
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigValues(
-				testResourceName, testNamespace, "test-update-values", []string{"foo: bar"},
+				testResourceName, testNamespace, "test-update-values", "stable/kibana", []string{"foo: bar"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
@@ -126,7 +126,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			),
 		}, {
 			Config: testAccHelmReleaseConfigValues(
-				testResourceName, testNamespace, "test-update-values", []string{"foo: baz"},
+				testResourceName, testNamespace, "test-update-values", "stable/kibana", []string{"foo: baz"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
@@ -144,7 +144,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigValues(
 				testResourceName, testNamespace, "test-update-multiple-values",
-				[]string{"foo: bar"},
+				"stable/kibana", []string{"foo: bar"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
@@ -154,7 +154,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 		}, {
 			Config: testAccHelmReleaseConfigValues(
 				testResourceName, testNamespace, "test-update-multiple-values",
-				[]string{"foo: bar", "foo: baz"},
+				"stable/kibana", []string{"foo: bar", "foo: baz"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
@@ -323,7 +323,7 @@ func testAccHelmReleaseConfigBasic(resource, ns, name, version string) string {
 	`, resource, name, ns, version)
 }
 
-func testAccHelmReleaseConfigValues(resource, ns, name string, values []string) string {
+func testAccHelmReleaseConfigValues(resource, ns, name, chart string, values []string) string {
 	vals := make([]string, len(values))
 	for i, v := range values {
 		vals[i] = strconv.Quote(v)
@@ -332,10 +332,10 @@ func testAccHelmReleaseConfigValues(resource, ns, name string, values []string) 
 		resource "helm_release" "%s" {
  			name      = %q
 			namespace = %q
-  			chart     = "stable/kibana"
+			chart     = %q
 			values    = [ %s ]
 		}
-	`, resource, name, ns, strings.Join(vals, ","))
+	`, resource, name, ns, chart, strings.Join(vals, ","))
 }
 
 func TestGetValues(t *testing.T) {


### PR DESCRIPTION
This moves status field out of metadata ~non-computed field~ and uses `CustomizeDiff` in order to track a state of Helm release and enforce that the state is `DEPLOYED`.

This fixes behavior when Terraform would ignore previously created release that is in a `FAILED` state and failed to try to bring it to the desired state (assuming this will always be `DEPLOYED`)

See https://github.com/terraform-providers/terraform-provider-helm/issues/159 for more detail (the issue has detailed steps about how to reproduce the issue).

This PR adds a test for this issue, to run the integration test(s):
- you need to have kube cluster setup & `kubectl` configured (verify by running `kubectl get pods`)
- you need to have Helm installed & Helm client configured (verify by running `helm list`)
- set env variable `TF_ACC` to `true` to enable acceptance tests (`export TF_ACC=true`)
- you need to have go 1.10+ installed and this project in correct path as per Go conventions(`$GOPATH/src/github.com/terraform-providers/terraform-provider-helm`)
- you can run all the tests by running
   ```
   go test -v helm/*
   ```
   ~but expect some of them to fail (I believe it's not related to this change, these were failing for me both with and without this code change),~
   To run just the test for this issue:
   ```
   go test -v -run "TestAccResourceRelease_updateExistingFailed" helm/*
   ```

**Update:** After rebasing on latest master and fixing 2 remaining tests (some fail only when running agains GKE and not when running against minikube) all the tests are expected to pass, both against minikube & GKE.