### PR TITLE
Fix build after dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ assets
 .terraform
 _output/
 .vscode
+/results

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -11,7 +11,7 @@ PROVIDER_NAME="helm"
 TARGET_DIR="$(pwd)/results"
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:=linux darwin windows freebsd openbsd solaris}
-XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386 !solaris/amd64"
+XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386 !solaris/amd64 !openbsd/386 !openbsd/amd64"
 LD_FLAGS="-s -w"
 export CGO_ENABLED=0
 


### PR DESCRIPTION
Builds were failing for the OpenBSD target. This change removes OpenBSD from the list of active targets.

As a result `make compile` now behaves as expected.
```
------------------------------------------------------------
~/work/src/github.com/terraform-providers/terraform-provider-helm(fix-build*) » make compile                                                                                                                                                                                                               alex@alexs-macbook
==> Checking that code complies with gofmt requirements...
Number of parallel builds: 7

-->     freebsd/arm: github.com/terraform-providers/terraform-provider-helm
-->       linux/386: github.com/terraform-providers/terraform-provider-helm
-->     freebsd/386: github.com/terraform-providers/terraform-provider-helm
-->     linux/amd64: github.com/terraform-providers/terraform-provider-helm
-->     windows/386: github.com/terraform-providers/terraform-provider-helm
-->    darwin/amd64: github.com/terraform-providers/terraform-provider-helm
-->   windows/amd64: github.com/terraform-providers/terraform-provider-helm
-->   freebsd/amd64: github.com/terraform-providers/terraform-provider-helm
-->       linux/arm: github.com/terraform-providers/terraform-provider-helm
------------------------------------------------------------
```
@terraform-providers/ecosystem 
@meyskens @rporres 