### PR TITLE
Add "overrides" attributes accumulating all overridden values for the release

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -262,7 +262,7 @@ func prepareTillerForNewRelease(d *schema.ResourceData, c helm.Interface, name s
 
 		switch r.Info.Status.GetCode() {
 		case release.Status_DEPLOYED:
-			return setIDAndMetadataFromRelease(d, r)
+			return setAttributesFromRelease(d, r)
 		case release.Status_FAILED:
 			// delete and recreate it
 			debug("release %s status is FAILED deleting it", name)
@@ -360,7 +360,7 @@ func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return setIDAndMetadataFromRelease(d, res.Release)
+	return setAttributesFromRelease(d, res.Release)
 }
 
 func resourceReleaseRead(d *schema.ResourceData, meta interface{}) error {
@@ -379,10 +379,10 @@ func resourceReleaseRead(d *schema.ResourceData, meta interface{}) error {
 
 	//  d.Set("values_source_detected_md5", d.Get("values_sources_md5"))
 
-	return setIDAndMetadataFromRelease(d, r)
+	return setAttributesFromRelease(d, r)
 }
 
-func setIDAndMetadataFromRelease(d *schema.ResourceData, r *release.Release) error {
+func setAttributesFromRelease(d *schema.ResourceData, r *release.Release) error {
 	d.SetId(r.Name)
 	d.Set("version", r.Chart.Metadata.Version)
 	d.Set("namespace", r.Namespace)
@@ -445,7 +445,7 @@ func resourceReleaseUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return setIDAndMetadataFromRelease(d, res.Release)
+	return setAttributesFromRelease(d, res.Release)
 }
 
 func resourceReleaseDelete(d *schema.ResourceData, meta interface{}) error {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -72,7 +72,7 @@ func resourceRelease() *schema.Resource {
 			"values": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "List of values in raw yaml format to pass to helm.",
+				Description: "List of values in raw yaml file to pass to helm.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"set": {
@@ -295,7 +295,6 @@ func prepareTillerForNewRelease(d *schema.ResourceData, c helm.Interface, name s
 }
 
 func resourceDiff(d *schema.ResourceDiff, meta interface{}) error {
-
 	// Always set desired state to DEPLOYED
 	err := d.SetNew("status", release.Status_DEPLOYED.String())
 	if err != nil {

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -135,7 +135,7 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{}\n"),
+				resource.TestCheckResourceAttr("helm_release.test", "overrides", "{}\n"),
 			),
 		}},
 	})
@@ -158,7 +158,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
+				resource.TestCheckResourceAttr("helm_release.test", "overrides", "foo: bar\n"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigValues(
@@ -167,7 +167,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: baz\n"),
+				resource.TestCheckResourceAttr("helm_release.test", "overrides", "foo: baz\n"),
 			),
 		}},
 	})
@@ -191,7 +191,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
+				resource.TestCheckResourceAttr("helm_release.test", "overrides", "foo: bar\n"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigValues(
@@ -201,7 +201,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: baz\n"),
+				resource.TestCheckResourceAttr("helm_release.test", "overrides", "foo: baz\n"),
 			),
 		}},
 	})

--- a/website/docs/release.html.markdown
+++ b/website/docs/release.html.markdown
@@ -83,17 +83,17 @@ The `set`, `set_sensitive` and `set_strings` blocks support:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `status` - Status of the release.
 * `metadata` - Block status of the deployed release.
+* `overrides` - YAML document representing the overriden values passed to the chart. It contains combined values from `values`, `set`, `set_secret` and `set_string` attributes.
 
-The `metadata` block supports:
+The `metadata` block contains the following keys:
 
 * `chart` - The name of the chart.
 * `name` - Name is the name of the release.
 * `namespace` - Namespace is the kubernetes namespace of the release.
 * `revision` - Version is an int32 which represents the version of the release.
-* `status` - Status of the release.
 * `version` - A SemVer 2 conformant version string of the chart.
-* `values` - The compounded values from `values` and `set*` attributes.
 
 ## Import
 


### PR DESCRIPTION
_Note:_  #150 will need to be rebased after merging this PR since it re-implements `"overrides"` attribute according to latest changes in master branch. I can handle this later too.

This PR does the following:
- Adds a new computed attribute called `overrides` which accumulates all values from `values`, `set`, `set_secret` and `set_string` attributes merged in the order they mentioned. This new attribute replaces the old `metadata.0.values` since it needs to be updated by `CustomizeDiff` func. 

- Changes the resource update logic. Now the update of the release will happen only if any of `overrides`, `status`, `version` or `reuse_values` attributes are changed or any of `recreate_pods` or `force_update`. Otherwise, there is no reason to call Chart's `UpdateRelease` API, so only the local state will be updated. 
That allows to safely move the same values between `values` / `set` / `set_secret` / `set_string` attributes, add comments & spaces to YAML, etc.  without calling a remote update on the tiller side.

This PR is also important for the future implementation of Importer (like #150), which could just dump all values to `overrides` without worrying about the diff caused by configuration in `*.tf`.