### PR TITLE
Fix helm repository read when local repository does not exist

### DIFF
--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -116,6 +117,11 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 
 	r, err := getRepository(d, m)
 	if err != nil {
+		if err == ErrRepositoryNotFound {
+			log.Printf("[WARN] Repository not found, removing from state: %#v", d.Get("name").(string))
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -133,10 +133,11 @@ func resourceRepositoryExists(d *schema.ResourceData, meta interface{}) (bool, e
 
 	_, err := getRepository(d, m)
 	if err == ErrRepositoryNotFound {
+		log.Printf("[WARN] Repository not found, removing from state: %#v", d.Get("name").(string))
 		return false, nil
-	} else {
-		return true, err
 	}
+
+	return true, err
 }
 
 func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {

--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -133,7 +133,7 @@ func resourceRepositoryExists(d *schema.ResourceData, meta interface{}) (bool, e
 
 	_, err := getRepository(d, m)
 	if err == ErrRepositoryNotFound {
-		log.Printf("[WARN] Repository not found, removing from state: %#v", d.Get("name").(string))
+		log.Printf("[DEBUG] Repository not found: %#v", d.Get("name").(string))
 		return false, nil
 	}
 

--- a/helm/resource_repository.go
+++ b/helm/resource_repository.go
@@ -18,6 +18,7 @@ func resourceRepository() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceRepositoryCreate,
 		Read:   resourceRepositoryRead,
+		Exists: resourceRepositoryExists,
 		Delete: resourceRepositoryDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -119,6 +120,17 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return setIDAndMetadataFromRepository(d, r)
+}
+
+func resourceRepositoryExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	m := meta.(*Meta)
+
+	_, err := getRepository(d, m)
+	if err == ErrRepositoryNotFound {
+		return false, nil
+	} else {
+		return true, err
+	}
 }
 
 func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This PR builds [on @rporres' suggestion](https://github.com/terraform-providers/terraform-provider-helm/pull/137#discussion_r227920062)  to resolve #146 and #163.

Note: an alternative solution may be to convert `helm_repository` resource into a datasource as it only alters the local helm repository and does not touch infrastructure.

FWIW, I'm currently testing my three recent PRs cumulatively from a [custom branch](https://github.com/pdecat/terraform-provider-helm/tree/test-cumulative) with a real use case.