### PR TITLE
helm_release: Suppress diff of "keyring" and "devel" attributes

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -63,7 +63,11 @@ func resourceRelease() *schema.Resource {
 			"devel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Use chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored",
+				Description: "Use chart development versions, too. Equivalent to version '>0.0.0-0'. If `version` is set, this is ignored",
+				// Suppress changes of this attribute if `version` is set
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("version").(string) != ""
+				},
 			},
 			"values": {
 				Type:        schema.TypeList,

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -144,7 +144,11 @@ func resourceRelease() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     os.ExpandEnv("$HOME/.gnupg/pubring.gpg"),
-				Description: "Location of public keys used for verification.",
+				Description: "Location of public keys used for verification. Used only if `verify` is true",
+				// Suppress changes of this attribute as it is just a local path
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 			"timeout": {
 				Type:        schema.TypeInt,

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -145,9 +145,9 @@ func resourceRelease() *schema.Resource {
 				Optional:    true,
 				Default:     os.ExpandEnv("$HOME/.gnupg/pubring.gpg"),
 				Description: "Location of public keys used for verification. Used only if `verify` is true",
-				// Suppress changes of this attribute as it is just a local path
+				// Suppress changes of this attribute if `verify` is false
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
+					return !d.Get("verify").(bool)
 				},
 			},
 			"timeout": {


### PR DESCRIPTION
- Suppress diff of `devel` attribute if `version` is set. In this case `devel` attribute is not used at all and its value shouldn't affect the resource state.

- Suppress diff of "keyring" attribute regardless of anything else. This attribute is only used for verifying chart on the download phase, and it is just a local path. So its value in the terraform state doesn't really matter.

Fixes #52

