### PR TITLE
Update default tiller image to v2.11.0 and document defaults

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -12,11 +12,12 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -97,7 +98,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc(helm_env.PluginDisableEnvVar, "true"),
-				Description: "Disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.",
+				Description: "Disable plugins. Set HELM_NO_PLUGINS=0 to enable plugins.",
 			},
 			"insecure": {
 				Type:        schema.TypeBool,

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -61,7 +61,7 @@ func Provider() terraform.ResourceProvider {
 			"tiller_image": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "gcr.io/kubernetes-helm/tiller:v2.9.0",
+				Default:     "gcr.io/kubernetes-helm/tiller:v2.11.0",
 				Description: "Tiller image to install.",
 			},
 			"service_account": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -80,21 +80,23 @@ i.e. any static field will override its counterpart loaded from the config.
 
 The following arguments are supported:
 
-* `host` - (Required) Set an alternative Tiller host. The format is host:port. Can be sourced from `HELM_HOST`.
-* `home` - (Required) Set an alternative location for Helm files. By default, these are stored in '$HOME/.helm'. Can be sourced from `HELM_HOME`.
-* `namespace` - (Optional) Set an alternative Tiller namespace.
-* `install_tiller` - (Optional) Install Tiller if it is not already installed.
-* `tiller_image` - (Optional) Tiller image to install.
-* `service_account` - (Optional) Service account to install Tiller with.
-* `automount_service_account_token` - (Optional) Auto-mount the given service account to tiller.
-* `debug` - (Optional)
-* `plugins_disable` - (Optional) Disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.
-* `enable_tls` - (Optional) Enables TLS communications with the Tiller.
-* `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. Can be sourced from `HELM_HOME`.
+* `host` - (Required) Set an alternative Tiller host. The format is host:port. Can be sourced from `HELM_HOST` environment variable.
+* `home` - (Required) Set an alternative location for Helm files. By default, these are stored in `$HOME/.helm`. Can be sourced from `HELM_HOME` environment variable.
+* `namespace` - (Optional) Set an alternative Tiller namespace. Defaults to `kube-system`.
+* `install_tiller` - (Optional) Install Tiller if it is not already installed. Defaults to `true`.
+* `tiller_image` - (Optional) Tiller image to install. Defaults to `gcr.io/kubernetes-helm/tiller:v2.11.0`.
+* `service_account` - (Optional) Service account to install Tiller with. Defaults to `default`.
+* `automount_service_account_token` - (Optional) Auto-mount the given service account to tiller. Defaults to `true`.
+* `override` - (Optional) Override values for the Tiller Deployment manifest. Defaults to `true`.
+* `max_history` - (Optional) Maximum number of release versions stored per release. Defaults to `0` (no limit).
+* `debug` - (Optional) - Debug indicates whether or not Helm is running in Debug mode. Defaults to `false`.
+* `plugins_disable` - (Optional) Disable plugins. Can be sourced from `HELM_NO_PLUGINS` environment variable, set `HELM_NO_PLUGINS=0` to enable plugins. Defaults to `true`.
+* `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. Defaults to `false`.
+* `enable_tls` - (Optional) Enables TLS communications with the Tiller. Defaults to `false`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. By default read from `$HELM_HOME/key.pem`.
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. By default read from `$HELM_HOME/cert.pem`.
 * `ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. By default read from `$HELM_HOME/ca.pem`.
-* `kubernetes` - Kubernetes configuration.
+* `kubernetes` - Kubernetes configuration block.
 
 The `kubernetes` block supports:
 


### PR DESCRIPTION
This PR mainly updates the default tiller image from `gcr.io/kubernetes-helm/tiller:v2.9.0` to `gcr.io/kubernetes-helm/tiller:v2.11.0` to match the [vendored version of the helm client libraries](https://github.com/terraform-providers/terraform-provider-helm/blob/master/glide.yaml#L4).

Also, this PR documents defaults used for the helm provider configuration.