### PR TITLE
Remove -i from 'go test' to allow running unit tests locally with go 1.11.x and GO111MODULE=on

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ build: fmtcheck
 	go build -v .
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
+	go test $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 


### PR DESCRIPTION
With `GO111MODULE=on`, running tests locally fail:

```
# make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
go test golang_org/x/crypto/cryptobyte/asn1: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/crypto/cryptobyte/asn1.a: permission denied
go test golang_org/x/net/dns/dnsmessage: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/net/dns/dnsmessage.a: permission denied
go test golang_org/x/crypto/curve25519: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/crypto/curve25519.a: permission denied
go test golang_org/x/crypto/internal/chacha20: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/crypto/internal/chacha20.a: permission denied
go test golang_org/x/crypto/poly1305: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/crypto/poly1305.a: permission denied
go test golang_org/x/text/transform: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/text/transform.a: permission denied
go test golang_org/x/net/http2/hpack: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/net/http2/hpack.a: permission denied
go test golang_org/x/text/unicode/bidi: open /usr/local/go/pkg/linux_amd64/vendor/golang_org/x/text/unicode/bidi.a: permission denied
make: *** [GNUmakefile:25: test] Error 1
```

The fix will be in go 1.12: https://github.com/golang/go/issues/27285

But won't be backported to go 1.11:
> This has a simple workaround (stop using `-i`) and the fix is invasive (renaming `src/vendor`), so probably not worth backporting.

cf. https://github.com/golang/go/issues/27389#issuecomment-439898728

cc @alexsomesan 