### PR TITLE
Using localhost for TillerHost leads to 'context deadline exceeded'

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -474,7 +474,7 @@ func (m *Meta) buildTunnel(d *schema.ResourceData) error {
 		return fmt.Errorf("error creating tunnel: %q", err)
 	}
 
-	m.Settings.TillerHost = fmt.Sprintf("localhost:%d", m.Tunnel.Local)
+	m.Settings.TillerHost = fmt.Sprintf("127.0.0.1:%d", m.Tunnel.Local)
 	debug("Created tunnel using local port: '%d'\n", m.Tunnel.Local)
 	return nil
 }


### PR DESCRIPTION
This appears to fix https://github.com/terraform-providers/terraform-provider-helm/issues/183. I am not 100% sure why this is happening, but when using Mac OSX against EKS, using `TillerHost` as `localhost` leads to "context deadline exceeded" error:

```
2019-02-07T10:13:08.061-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/07 10:13:08 [DEBUG] Created tunnel using local port: '54606'
2019-02-07T10:13:13.067-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/07 10:13:13 [DEBUG] could not get release context deadline exceeded
```

Changing it to `127.0.0.1` as proposed here fixed this:

```
2019-02-07T10:16:31.122-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/07 10:16:31 [DEBUG] Created tunnel using local port: '54851'
2019-02-07T10:16:31.910-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/07 10:16:31 [DEBUG] Fetched stable/kube2iam to /Users/yoriy/.helm/cache/archive/kube2iam-0.10.0.tgz
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/07 10:16:31 ---[ values.yaml ]-----------------------------------
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm: extraArgs:
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm:   namespace-restrictions: ""
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm: host:
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm:   interface: eni+
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm:   iptables: false
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm:   port: 8181
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm: rbac:
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm:   create: true
2019-02-07T10:16:31.912-0800 [DEBUG] plugin.terraform-provider-helm:
```