### PR TITLE
Use configured helm home when reading default TLS settings

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -113,19 +114,16 @@ func Provider() terraform.ResourceProvider {
 			"client_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "$HELM_HOME/key.pem",
 				Description: "PEM-encoded client certificate key for TLS authentication.",
 			},
 			"client_certificate": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "$HELM_HOME/cert.pem",
 				Description: "PEM-encoded client certificate for TLS authentication.",
 			},
 			"ca_certificate": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "$HELM_HOME/ca.pem",
 				Description: "PEM-encoded root certificates bundle for TLS authentication.",
 			},
 			"kubernetes": {
@@ -485,6 +483,7 @@ func (m *Meta) buildHelmClient() helm.Interface {
 	}
 
 	if m.TLSConfig != nil {
+		debug("Found TLS settings: configuring helm client with TLS")
 		options = append(options, helm.WithTLS(m.TLSConfig))
 	}
 
@@ -492,11 +491,17 @@ func (m *Meta) buildHelmClient() helm.Interface {
 }
 
 func (m *Meta) buildTLSConfig(d *schema.ResourceData) error {
-	keyPEMBlock, err := getContent(d, "client_key", "$HELM_HOME/key.pem")
+	// The default uses the files in the provider configured helm home
+	helmHome := d.Get("home").(string)
+	clientKeyDefault := filepath.Join(helmHome, "key.pem")
+	clientCertDefault := filepath.Join(helmHome, "cert.pem")
+	caCertDefault := filepath.Join(helmHome, "ca.pem")
+
+	keyPEMBlock, err := getContent(d, "client_key", clientKeyDefault)
 	if err != nil {
 		return err
 	}
-	certPEMBlock, err := getContent(d, "client_certificate", "$HELM_HOME/cert.pem")
+	certPEMBlock, err := getContent(d, "client_certificate", clientCertDefault)
 	if err != nil {
 		return err
 	}
@@ -515,7 +520,7 @@ func (m *Meta) buildTLSConfig(d *schema.ResourceData) error {
 
 	cfg.Certificates = []tls.Certificate{cert}
 
-	caPEMBlock, err := getContent(d, "ca_certificate", "$HELM_HOME/ca.pem")
+	caPEMBlock, err := getContent(d, "ca_certificate", caCertDefault)
 	if err != nil {
 		return err
 	}
@@ -532,14 +537,19 @@ func (m *Meta) buildTLSConfig(d *schema.ResourceData) error {
 }
 
 func getContent(d *schema.ResourceData, key, def string) ([]byte, error) {
+	// Check if the key is defined. If not, use the default.
 	filename := d.Get(key).(string)
+	if filename == "" {
+		filename = def
+	}
+	debug("TLS settings: Attempting to read contents of %s from %s", key, filename)
 
 	content, _, err := pathorcontents.Read(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	if content == def {
+	if content == filename {
 		return nil, nil
 	}
 

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -549,7 +549,7 @@ func getContent(d *schema.ResourceData, key, def string) ([]byte, error) {
 		return nil, err
 	}
 
-	if content == filename {
+	if content == def {
 		return nil, nil
 	}
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -93,9 +93,9 @@ The following arguments are supported:
 * `plugins_disable` - (Optional) Disable plugins. Can be sourced from `HELM_NO_PLUGINS` environment variable, set `HELM_NO_PLUGINS=0` to enable plugins. Defaults to `true`.
 * `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. Defaults to `false`.
 * `enable_tls` - (Optional) Enables TLS communications with the Tiller. Defaults to `false`.
-* `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. By default read from `$HELM_HOME/key.pem`.
-* `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. By default read from `$HELM_HOME/cert.pem`.
-* `ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. By default read from `$HELM_HOME/ca.pem`.
+* `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. By default read from `key.pem` in the location set by `home`.
+* `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. By default read from `cert.pem` in the location set by `home`.
+* `ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. By default read from `ca.pem` in the location set by `home`.
 * `kubernetes` - Kubernetes configuration block.
 
 The `kubernetes` block supports:


### PR DESCRIPTION
This is a proposed changeset that tweaks the default values of `client_key`, `client_certificate`, and `ca_certificate`.

Specifically, the current behavior mimics the client in looking for the files `key.pem`, `cert.pem`, and `ca.pem` in `HELM_HOME`. However, if you have `HELM_HOME` env var unset, then it does not fall back to looking in the default helm home `$HOME/.helm` because it renders the env var directly.

This PR instead attempts to use the value of the `home` option on the provider, which does the proper resolution of the helm home directory.

Additionally, I added some debug statements around the TLS settings. This was helpful in realizing my TLS config wasn't being read despite having them in my home directory. Otherwise, you get an unhelpful error message:

```
2019-02-08T10:37:54.021-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/08 10:37:54 [DEBUG] Created tunnel using local port: '50838'
2019-02-08T10:37:54.669-0800 [DEBUG] plugin.terraform-provider-helm: 2019/02/08 10:37:54 [DEBUG] could not get release rpc error: code = Unavailable desc = tr
ansport is closing
```