### PR TITLE
Fix Travis and Minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
         - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 
         - sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
         - sudo minikube start --vm-driver=none --kubernetes-version=${KUBERNETES_VERSION}
+        - sudo chown -R travis /home/travis/.minikube/
         - minikube update-context
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh


### PR DESCRIPTION
Acceptance tests were failing inside Travis due an error with minikube:
```
minikube update-context
!   Error host driver ip status: Error loading store for: minikube: filestore: open /home/travis/.minikube/machines/minikube/config.json: permission denied
```