### PR TITLE
Log notes.txt to INFO

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -560,6 +560,10 @@ func debug(format string, a ...interface{}) {
 	log.Printf("[DEBUG] %s", fmt.Sprintf(format, a...))
 }
 
+func info(format string, a ...interface{}) {
+	log.Printf("[INFO] %s", fmt.Sprintf(format, a...))
+}
+
 var (
 	tlsCaCertFile string // path to TLS CA certificate file
 	tlsCertFile   string // path to TLS certificate file

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -349,6 +349,8 @@ func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	info(res.GetRelease().GetInfo().GetStatus().GetNotes())
+
 	return setIDAndMetadataFromRelease(d, res.Release)
 }
 
@@ -420,6 +422,8 @@ func resourceReleaseUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	info(res.GetRelease().GetInfo().GetStatus().GetNotes())
 
 	return setIDAndMetadataFromRelease(d, res.Release)
 }


### PR DESCRIPTION
This PR logs `notes.txt` to the INFO level of Terraform logging

Fixes #181 