### PR TITLE
Replace 'O' with '0' in unreleased version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## O.9.0 (Unreleased)
+## 0.9.0 (Unreleased)
 
 FEATURES:
 


### PR DESCRIPTION
Fix a typo.