### PR TITLE
Don't enable TLS if `enable_tls` is false

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -532,6 +532,11 @@ func (m *Meta) buildHelmClient() helm.Interface {
 }
 
 func (m *Meta) buildTLSConfig(d *schema.ResourceData) error {
+	// Don't initialize TLSConfig if TLS is disabled
+	if !d.Get("enable_tls").(bool) {
+		return nil
+	}
+
 	// The default uses the files in the provider configured helm home
 	helmHome := d.Get("home").(string)
 	clientKeyDefault := filepath.Join(helmHome, "key.pem")


### PR DESCRIPTION
Terraform Helm provider 0.9.0 introduces a regression. In 0.8.0 if there
is no `client_key`, `ca_certificate`, or `client_certificate` defined at
the `provider "Helm"` level, TLS configuration is effectively disabled.
The 0.9.0 version checks if there are `key.pem`, `cert.pem` and `ca.pem`
present in Helm's home directory and if they are, TLS is enabled. This
behaviour can break some configurations where these certificate files
are present for other cluster(s) but current cluster doesn't use TLS.

This change makes the Helm provider behave similar to Helm CLI. Helm
CLI uses `--tls` option to explicitely enable TLS. This change makes
`enable_tls` option to work as advertised (quoting documentation:
`enable_tls` - (Optional) Enables TLS communications with the Tiller.
Defaults to `false`).

Fixes #244 