### PR TITLE
TLS improvements

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -118,6 +118,11 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				Description: "Enables TLS communications with the Tiller.",
 			},
+			"tls_hostname": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The hostname or IP address used to verify the Tiller server certificate.",
+			},
 			"client_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -582,6 +587,7 @@ func (m *Meta) buildTLSConfig(d *schema.ResourceData) error {
 
 	cfg := &tls.Config{
 		InsecureSkipVerify: d.Get("insecure").(bool),
+		ServerName:         d.Get("tls_hostname").(string),
 	}
 
 	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)


### PR DESCRIPTION
Refs #191 #175

Hi, I'm creating this pull request to share my idea of automatic deployment of helm with Terraform. Maybe someone could help me finishing it, so we can push it upstream.

This patches introduces breaking change: `client_key` is now replaced by `client_key_path`. Perhaps we could support both file path and certificate content on the same parameter, but I think eventually, only certificate content should be allowed, since user can always use `file()` function.

I have following Terraform code, which works perfectly with these patches:
```
resource "tls_private_key" "helm_ca" {
  algorithm   = "ECDSA"
  ecdsa_curve = "P384"
}

resource "tls_self_signed_cert" "helm_ca" {
  key_algorithm   = "${tls_private_key.helm_ca.algorithm}"
  private_key_pem = "${tls_private_key.helm_ca.private_key_pem}"

  subject {
    common_name  = "ca.helm.${var.domain}"
    organization = "${var.domain}"
  }

  validity_period_hours = 86400

  is_ca_certificate = true

  allowed_uses = [
    "cert_signing",
    "key_encipherment",
    "digital_signature",
  ]
}

resource "local_file" "helm_ca_cert" {
  sensitive_content = "${tls_self_signed_cert.helm_ca.cert_pem}"
  filename          = ".secrets/helm_ca_cert.pem"
}

resource "tls_private_key" "helm_server" {
  algorithm   = "ECDSA"
  ecdsa_curve = "P384"
}

resource "local_file" "helm_server_key" {
  sensitive_content = "${tls_private_key.helm_server.private_key_pem}"
  filename          = ".secrets/helm_server_key.pem"
}

resource "tls_cert_request" "helm_server_cert" {
  key_algorithm   = "${tls_private_key.helm_server.algorithm}"
  private_key_pem = "${tls_private_key.helm_server.private_key_pem}"

  subject {
    common_name  = "server.helm.${var.domain}"
    organization = "${var.domain}"
  }

  dns_names    = [ "localhost" ]
  ip_addresses = [ "127.0.0.1" ]
}

resource "tls_locally_signed_cert" "helm_server_cert" {
  cert_request_pem = "${tls_cert_request.helm_server_cert.cert_request_pem}"

  ca_key_algorithm   = "${tls_private_key.helm_ca.algorithm}"
  ca_private_key_pem = "${tls_private_key.helm_ca.private_key_pem}"
  ca_cert_pem        = "${tls_self_signed_cert.helm_ca.cert_pem}"

  validity_period_hours = 86400
  allowed_uses          = [
    "key_encipherment",
    "digital_signature",
    "server_auth",
  ]
}

resource "local_file" "helm_server_cert" {
  sensitive_content = "${tls_locally_signed_cert.helm_server_cert.cert_pem}"
  filename          = ".secrets/helm_server_cert.pem"
}

resource "tls_private_key" "helm_terraform" {
  algorithm   = "ECDSA"
  ecdsa_curve = "P384"
}

resource "local_file" "helm_terraform_key" {
  sensitive_content = "${tls_private_key.helm_terraform.private_key_pem}"
  filename          = ".secrets/helm_terraform_key.pem"
}

resource "tls_cert_request" "helm_terraform_cert" {
  key_algorithm   = "${tls_private_key.helm_terraform.algorithm}"
  private_key_pem = "${tls_private_key.helm_terraform.private_key_pem}"

  subject {
    common_name  = "terraform.helm.${var.domain}"
    organization = "${var.domain}"
  }
}

resource "tls_locally_signed_cert" "helm_terraform_cert" {
  cert_request_pem = "${tls_cert_request.helm_terraform_cert.cert_request_pem}"

  ca_key_algorithm   = "${tls_private_key.helm_ca.algorithm}"
  ca_private_key_pem = "${tls_private_key.helm_ca.private_key_pem}"
  ca_cert_pem        = "${tls_self_signed_cert.helm_ca.cert_pem}"

  validity_period_hours = 86400
  allowed_uses          = [
    "key_encipherment",
    "digital_signature",
    "client_auth",
  ]
}

resource "local_file" "helm_terraform_cert" {
  sensitive_content = "${tls_locally_signed_cert.helm_terraform_cert.cert_pem}"
  filename          = ".secrets/helm_terraform_cert.pem"
}

resource "tls_private_key" "helm_client" {
  algorithm   = "ECDSA"
  ecdsa_curve = "P384"
}

resource "local_file" "helm_client_key" {
  sensitive_content = "${tls_private_key.helm_client.private_key_pem}"
  filename          = ".secrets/helm_client_key.pem"
}

resource "tls_cert_request" "helm_client_cert" {
  key_algorithm   = "${tls_private_key.helm_client.algorithm}"
  private_key_pem = "${tls_private_key.helm_client.private_key_pem}"

  subject {
    common_name  = "client.helm.${var.domain}"
    organization = "${var.domain}"
  }
}

resource "tls_locally_signed_cert" "helm_client_cert" {
  cert_request_pem = "${tls_cert_request.helm_client_cert.cert_request_pem}"

  ca_key_algorithm   = "${tls_private_key.helm_ca.algorithm}"
  ca_private_key_pem = "${tls_private_key.helm_ca.private_key_pem}"
  ca_cert_pem        = "${tls_self_signed_cert.helm_ca.cert_pem}"

  validity_period_hours = 86400
  allowed_uses          = [
    "key_encipherment",
    "digital_signature",
    "client_auth",
  ]
}

resource "local_file" "helm_client_cert" {
  sensitive_content = "${tls_locally_signed_cert.helm_client_cert.cert_pem}"
  filename          = ".secrets/helm_client_cert.pem"
}

resource "kubernetes_service_account" "tiller" {
  metadata {
    name = "tiller"
    namespace = "kube-system"
  }
}

resource "kubernetes_cluster_role_binding" "tiller" {
  metadata {
    name = "tiller"
  }
  role_ref {
    api_group = "rbac.authorization.k8s.io"
    kind = "ClusterRole"
    name = "cluster-admin"
  }
  subject {
    api_group = ""
    kind = "ServiceAccount"
    name = "tiller"
    namespace = "kube-system"
  }

  depends_on = [ "kubernetes_service_account.tiller" ]
}


resource "null_resource" "helm_init" {
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/helm_server_cert.pem ]; then echo '.secrets/helm_server_cert.pem does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/helm_server_key.pem ]; then echo '.secrets/helm_server_key.pem does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/helm_ca_cert.pem ]; then echo '.secrets/helm_ca_cert.pem does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/kube_config_cluster.yml ]; then echo '.secrets/kube_config_cluster.yml does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "helm init --service-account tiller --upgrade --override 'spec.template.spec.containers[0].args'='{-listen=localhost:44134,-storage=secret}' --tiller-tls --tiller-tls-verify --tiller-tls-cert .secrets/helm_server_cert.pem --tiller-tls-key .secrets/helm_server_key.pem --tls-ca-cert .secrets/helm_ca_cert.pem"
    environment {
      KUBECONFIG = "${path.root}/.secrets/kube_config_cluster.yml"
    }
  }

  depends_on = [
    "kubernetes_cluster_role_binding.tiller",
    "local_file.kube_config_cluster",
    "local_file.helm_ca_cert",
    "local_file.helm_server_key",
    "local_file.helm_server_cert",
  ]
}

resource "null_resource" "helm_wait" {
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/helm_ca_cert.pem ]; then echo '.secrets/helm_ca_cert.pem does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/helm_terraform_cert.pem ]; then echo '.secrets/helm_terraform_cert.pem does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/helm_terraform_key.pem ]; then echo '.secrets/helm_terraform_key.pem does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }
  provisioner "local-exec" {
    command = "if [ ! -f .secrets/kube_config_cluster.yml ]; then echo '.secrets/kube_config_cluster.yml does not exist'; exit 1; fi"
    interpreter = ["/bin/bash", "-c"]
  }

  provisioner "local-exec" {
    # Wait up to 5 min waiting for tiller
    command = "for i in {1..60}; do helm version --tls --tls-verify --tls-ca-cert .secrets/helm_ca_cert.pem --tls-cert .secrets/helm_terraform_cert.pem --tls-key .secrets/helm_terraform_key.pem --tiller-connection-timeout 4 --tls-hostname=localhost >/dev/null 2>&1 && exit 0 || sleep 1; done; exit 1"
    environment {
      KUBECONFIG = "${path.root}/.secrets/kube_config_cluster.yml"
    }
    interpreter = ["/bin/bash", "-c"]
  }

  depends_on = [
    "null_resource.helm_init",
    "local_file.kube_config_cluster",
    "local_file.helm_ca_cert",
    "local_file.helm_terraform_key",
    "local_file.helm_terraform_cert",
  ]
}

provider "helm" {
  version = "~> 0.9.0"

  client_certificate = "${tls_locally_signed_cert.helm_terraform_cert.cert_pem}"
  client_key         = "${tls_private_key.helm_terraform.private_key_pem}"
  ca_certificate     = "${tls_self_signed_cert.helm_ca.cert_pem}"
  enable_tls         = true
  tls_hostname       = "localhost"

  kubernetes { skipped }
}

provider "tls" {
  version = "~> 1.2.0"
}

provider "local" {
  version = "~> 1.2.1"
}

provider "null" {
  version = "~> 2.1.1"
}
```