### PR TITLE
tf-012: fix acceptance tests failures related to metadata updates

### DIFF
--- a/helm/data_repository.go
+++ b/helm/data_repository.go
@@ -51,7 +51,7 @@ func dataRepository() *schema.Resource {
 				Description: "Password for HTTP basic authentication",
 			},
 			"metadata": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Status of the deployed release",
 				Elem: &schema.Resource{

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -202,7 +202,7 @@ func resourceRelease() *schema.Resource {
 				Description: "Status of the release.",
 			},
 			"metadata": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Status of the deployed release.",
 				Elem: &schema.Resource{

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -640,7 +640,7 @@ func deleteNamespace(t *testing.T, namespace string) {
 		t.Fatal("provider not properly initialized")
 	}
 
-	t.Logf("[DEBUG] Deleting namespace %q", namespace)
+	debug("[DEBUG] Deleting namespace %q", namespace)
 	gracePeriodSeconds := int64(0)
 	deleteOptions := meta_v1.DeleteOptions{
 		GracePeriodSeconds: &gracePeriodSeconds,

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -355,7 +355,7 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 }
 
 func TestAccResourceRelease_updateVersionFromRelease(t *testing.T) {
-	name := fmt.Sprintf("test-update-existing-failed-%s", acctest.RandString(10))
+	name := fmt.Sprintf("test-update-version-from-release-%s", acctest.RandString(10))
 	namespace := fmt.Sprintf("%s-%s", testNamespace, acctest.RandString(10))
 	// Delete namespace automatically created by helm after checks
 	defer deleteNamespace(t, namespace)


### PR DESCRIPTION
This resolves the following acceptance tests failures related to metadata updates:

```
--- FAIL: TestAccResourceRelease_updateVersionFromRelease (39.52s)
    testing.go:568: Step 1 error: Check failed: 2 errors occurred:
                * Check 1/4 error: helm_release.test: Attribute 'metadata.0.revision' expected "2", got "1"
                * Check 2/4 error: helm_release.test: Attribute 'metadata.0.version' expected "0.6.3", got "0.6.2"


    resource_release_test.go:643: [DEBUG] Deleting namespace "terraform-acc-test-ywmnpo1yqb"
```

```
--- FAIL: TestAccResourceRelease_repository (0.01s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:
        
        - using helm_repository as a resource is deprecated; consider using the data source instead
        - Invalid index: This value does not have any indices.
    resource_release_test.go:650: An error occurred while deleting namespace "terraform-acc-test-l8t0uuvsa3": "namespaces \"terraform-acc-test-l8t0uuvsa3\" not found"
```