### PR TITLE
CI: update kubernetes to latest v1.10.x minor version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       stage: Acceptance test
       env:
         - CHANGE_MINIKUBE_NONE_USER=true
-        - KUBERNETES_VERSION=v1.10.0
+        - KUBERNETES_VERSION=v1.10.13
       install:
         - sudo apt-get update
         - sudo apt-get install -y socat


### PR DESCRIPTION
Latest v1.10.x minor version is v1.10.13 nowadays.