### PR TITLE
Add acceptance test cases for concurrent repositories additions issue

### DIFF
--- a/helm/provider_test.go
+++ b/helm/provider_test.go
@@ -32,3 +32,10 @@ func TestProvider(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func testAccPreCheck(t *testing.T) {
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -312,8 +312,13 @@ func resourceDiff(d *schema.ResourceDiff, meta interface{}) error {
 		return nil
 	}
 
-	// Set desired version from the Chart metadata
-	return d.SetNew("version", c.Metadata.Version)
+	// Set desired version from the Chart metadata if available
+	if len(c.Metadata.Version) > 0 {
+		return d.SetNew("version", c.Metadata.Version)
+	} else {
+		return d.SetNewComputed("version")
+	}
+
 }
 
 func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -251,6 +251,59 @@ func TestAccResourceRelease_repository(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_repositoryDatasource(t *testing.T) {
+	name := fmt.Sprintf("test-repository-%s", acctest.RandString(10))
+	namespace := fmt.Sprintf("%s-%s", testNamespace, acctest.RandString(10))
+	// Delete namespace automatically created by helm after checks
+	defer deleteNamespace(t, namespace)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{{
+			Config: testAccHelmReleaseConfigRepositoryDatasource(testResourceName, namespace, name),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
+				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
+			),
+		}, {
+			Config: testAccHelmReleaseConfigRepositoryDatasource(testResourceName, namespace, name),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
+				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
+			),
+		}},
+	})
+}
+
+func TestAccResourceRelease_repositoryMultipleDatasources(t *testing.T) {
+	name := fmt.Sprintf("test-repository-%s", acctest.RandString(10))
+	namespace := fmt.Sprintf("%s-%s", testNamespace, acctest.RandString(10))
+	// Delete namespace automatically created by helm after checks
+	defer deleteNamespace(t, namespace)
+
+	repo1 := "test-acc-repo-1"
+	repo2 := "test-acc-repo-2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckHelmRepositoryDestroy(t, repo1)
+			testAccPreCheckHelmRepositoryDestroy(t, repo2)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{{
+			Config: testAccHelmReleaseConfigRepositoryMultipleDatasource(repo1, repo2, testResourceName, namespace, name),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
+				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
+			),
+		}},
+	})
+}
+
 func TestAccResourceRelease_repository_url(t *testing.T) {
 	name := fmt.Sprintf("test-repository-url-%s", acctest.RandString(10))
 	namespace := fmt.Sprintf("%s-%s", testNamespace, acctest.RandString(10))
@@ -526,6 +579,50 @@ func testAccHelmReleaseConfigRepository(resource, ns, name string) string {
 			chart      = "coredns"
 		}
 	`, resource, name, ns)
+}
+
+func testAccHelmReleaseConfigRepositoryDatasource(resource, ns, name string) string {
+	return fmt.Sprintf(`
+		data "helm_repository" "stable_repo" {
+			name = "stable-repo"
+			url  = "https://kubernetes-charts.storage.googleapis.com"
+		}
+
+		resource "helm_release" %q {
+			name       = %q
+			namespace  = %q
+			repository = "${data.helm_repository.stable_repo.metadata.0.name}"
+			chart      = "coredns"
+		}
+	`, resource, name, ns)
+}
+
+func testAccHelmReleaseConfigRepositoryMultipleDatasource(repo1, repo2, resource, ns, name string) string {
+	return fmt.Sprintf(`
+		data "helm_repository" "stable_repo" {
+			name = %q
+			url  = "https://kubernetes-charts.storage.googleapis.com"
+		}
+
+		data "helm_repository" "stable_repo_2" {
+			name = %q
+			url  = "https://kubernetes-charts.storage.googleapis.com"
+		}
+
+		resource "helm_release" %q {
+			name       = %q
+			namespace  = %q
+			repository = "${data.helm_repository.stable_repo.metadata.0.name}"
+			chart      = "coredns"
+		}
+
+		resource "helm_release" %q {
+			name       = %q
+			namespace  = %q
+			repository = "${data.helm_repository.stable_repo_2.metadata.0.name}"
+			chart      = "coredns"
+		}
+	`, repo1, repo2, resource, name, ns, resource+"_2", name+"-2", ns)
 }
 
 func testAccHelmReleaseConfigRepositoryURL(resource, ns, name string) string {

--- a/helm/resource_repository_test.go
+++ b/helm/resource_repository_test.go
@@ -2,10 +2,7 @@ package helm
 
 import (
 	"fmt"
-	"os"
 	"testing"
-
-	"k8s.io/helm/pkg/repo"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -50,30 +47,4 @@ func testAccHelmRepositoryConfigBasic(name, url string) string {
 			url  = %q
 		}
 	`, name, url)
-}
-
-func testAccPreCheckHelmRepositoryDestroy(t *testing.T, name string) {
-	settings := testAccProvider.Meta().(*Meta).Settings
-
-	repoFile := settings.Home.RepositoryFile()
-	r, err := repo.LoadRepositoriesFile(repoFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !r.Remove(name) {
-		t.Log(fmt.Sprintf("no repo named %q found, nothing to do", name))
-		return
-	}
-	if err := r.WriteFile(repoFile, 0644); err != nil {
-		t.Fatalf("Failed to write repositories file: %s", err)
-	}
-
-	if _, err := os.Stat(settings.Home.CacheIndex(name)); err == nil {
-		err = os.Remove(settings.Home.CacheIndex(name))
-		if err != nil {
-			t.Fatalf("Failed to remove repository cache: %s", err)
-		}
-	}
-
-	t.Log(fmt.Sprintf("%q has been removed from your repositories\n", name))
 }


### PR DESCRIPTION
Acceptance test result on the `fix-271` branch:

```
# make testacc TESTARGS='-run=TestAccResourceRelease_repository.*Datasource -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run=TestAccResourceRelease_repository.*Datasource -count=1 -timeout 120m -parallel=4
=== RUN   TestAccResourceRelease_repositoryDatasource
=== PAUSE TestAccResourceRelease_repositoryDatasource
=== RUN   TestAccResourceRelease_repositoryMultipleDatasources
=== PAUSE TestAccResourceRelease_repositoryMultipleDatasources
=== CONT  TestAccResourceRelease_repositoryDatasource
=== CONT  TestAccResourceRelease_repositoryMultipleDatasources
--- PASS: TestAccResourceRelease_repositoryDatasource (58.08s)
--- PASS: TestAccResourceRelease_repositoryMultipleDatasources (70.60s)
    resource_repository_test.go:78: "test-acc-repo-1" has been removed from your repositories

    resource_repository_test.go:78: "test-acc-repo-2" has been removed from your repositories

PASS
ok      github.com/terraform-providers/terraform-provider-helm/helm     70.654s
```

The same diff applied to master triggers the following acceptance test failures:

```
# make testacc TESTARGS='-run=TestAccResourceRelease_repository.*Datasource -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run=TestAccResourceRelease_repository.*Datasource -count=1 -timeout 120m -parallel=4
=== RUN   TestAccResourceRelease_repositoryDatasource
=== PAUSE TestAccResourceRelease_repositoryDatasource
=== RUN   TestAccResourceRelease_repositoryMultipleDatasources
=== PAUSE TestAccResourceRelease_repositoryMultipleDatasources
=== CONT  TestAccResourceRelease_repositoryDatasource
=== CONT  TestAccResourceRelease_repositoryMultipleDatasources
--- FAIL: TestAccResourceRelease_repositoryMultipleDatasources (40.49s)
    resource_repository_test.go:64: no repo named "test-acc-repo-1" found, nothing to do
    resource_repository_test.go:64: no repo named "test-acc-repo-2" found, nothing to do
    testing.go:568: Step 0 error: errors during apply:

        Error: repo test-acc-repo-2 not found

          on /tmp/tf-test115248474/main.tf line 19:
          (source code not available)


--- PASS: TestAccResourceRelease_repositoryDatasource (59.15s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-helm/helm     59.219s
```
```
# make testacc TESTARGS='-run=TestAccResourceRelease_repository.*Datasource -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run=TestAccResourceRelease_repository.*Datasource -count=1 -timeout 120m -parallel=4
=== RUN   TestAccResourceRelease_repositoryDatasource
=== PAUSE TestAccResourceRelease_repositoryDatasource
=== RUN   TestAccResourceRelease_repositoryMultipleDatasources
=== PAUSE TestAccResourceRelease_repositoryMultipleDatasources
=== CONT  TestAccResourceRelease_repositoryDatasource
=== CONT  TestAccResourceRelease_repositoryMultipleDatasources
--- FAIL: TestAccResourceRelease_repositoryMultipleDatasources (45.47s)
    resource_repository_test.go:64: no repo named "test-acc-repo-1" found, nothing to do
    resource_repository_test.go:64: no repo named "test-acc-repo-2" found, nothing to do
    testing.go:568: Step 0 error: errors during apply:

        Error: repo test-acc-repo-1 not found

          on /tmp/tf-test499338862/main.tf line 12:
          (source code not available)


--- PASS: TestAccResourceRelease_repositoryDatasource (61.85s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-helm/helm     61.896s
```
```
make testacc TESTARGS='-run=TestAccResourceRelease_repository.*Datasource -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run=TestAccResourceRelease_repository.*Datasource -count=1 -timeout 120m -parallel=4
=== RUN   TestAccResourceRelease_repositoryDatasource
=== PAUSE TestAccResourceRelease_repositoryDatasource
=== RUN   TestAccResourceRelease_repositoryMultipleDatasources
=== PAUSE TestAccResourceRelease_repositoryMultipleDatasources
=== CONT  TestAccResourceRelease_repositoryDatasource
=== CONT  TestAccResourceRelease_repositoryMultipleDatasources
--- FAIL: TestAccResourceRelease_repositoryMultipleDatasources (41.34s)
    resource_repository_test.go:78: "test-acc-repo-1" has been removed from your repositories

    resource_repository_test.go:78: "test-acc-repo-2" has been removed from your repositories

    testing.go:568: Step 0 error: errors during apply:

        Error: repo test-acc-repo-1 not found

          on /tmp/tf-test243619408/main.tf line 12:
          (source code not available)



        Error: Provider produced inconsistent final plan

        When expanding the plan for helm_release.test_2 to include new values learned
        so far during apply, provider "helm" produced an invalid new value for
        .version: was known, but now unknown.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

    resource_release_test.go:747: An error occurred while deleting namespace "terraform-acc-test-ltu9xgzetp": "namespaces \"terraform-acc-test-ltu9xgzetp\" not found"
--- PASS: TestAccResourceRelease_repositoryDatasource (58.44s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-helm/helm     58.495s
```