### PR TITLE
Update the example of helm_repository

### DIFF
--- a/website/docs/repository.html.markdown
+++ b/website/docs/repository.html.markdown
@@ -21,7 +21,7 @@ data "helm_repository" "incubator" {
 }
 
 resource "helm_release" "my_cache" {
-    name       = "my_cache"
+    name       = "my-cache"
     repository = "${data.helm_repository.incubator.metadata.0.name}"
     chart      = "redis-cache"
 }


### PR DESCRIPTION
Release name of incubator/redis-cache chart cannot contain underscore, as it's used in a service name, and should be in DNS-1035 label format.

The following error will be shown if `my_cache` is used as the release name:

> * helm_release.my_cache: rpc error: code = Unknown desc = release my_cache failed: Service "my_cache-redis-cache" is invalid: metadata.name: Invalid value: "my_cache-redis-cache": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is `[a-z]([-a-z0-9]*[a-z0-9])?`)