### PR TITLE
Fail on invalid chart

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -306,10 +306,10 @@ func resourceDiff(d *schema.ResourceDiff, meta interface{}) error {
 		return err
 	}
 
-	// Get Chart metadata, if we fail - we're done
+	// Get Chart metadata, if we fail - Terraform should fail
 	c, _, err := getChart(d, meta.(*Meta))
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to get chart metadata (malformed chart?): %v", err)
 	}
 
 	// Set desired version from the Chart metadata


### PR DESCRIPTION
Current situtation: if the chart is malformed, but the Helm release was already installed earlier, `terraform apply` will not display any error. I have a case where no `resource "helm_release" "foo" { version = ...` is given, so always the latest chart version should be taken. Terraform would then not hint that the chart is malformed, but silently "succeed", i.e. return an empty plan/apply result and the chart upgrade won't be attempted.

This patch fixes that and adds two tests (problems in `Chart.yaml` and `requirements.yaml`, respectively).