### PR TITLE
Wait for tiller if it's not ready

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -500,6 +500,13 @@ func (m *Meta) buildTunnel(d *schema.ResourceData) error {
 		return nil
 	}
 
+	// Wait a reasonable time for tiller, even if we didn't deploy it this run
+	o := &installer.Options{}
+	o.Namespace = d.Get("namespace").(string)
+	if err := m.waitForTiller(o); err != nil {
+		return err
+	}
+
 	var err error
 	m.Tunnel, err = portforwarder.New(m.Settings.TillerNamespace, m.K8sClient, m.K8sConfig)
 	if err != nil {

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -502,7 +502,7 @@ func (m *Meta) buildTunnel(d *schema.ResourceData) error {
 
 	// Wait a reasonable time for tiller, even if we didn't deploy it this run
 	o := &installer.Options{}
-	o.Namespace = d.Get("namespace").(string)
+	o.Namespace = m.Settings.TillerNamespace
 	if err := m.waitForTiller(o); err != nil {
 		return err
 	}


### PR DESCRIPTION
If tiller has failed for some reason; wait a reasonable amount of time to see if the pod/service will return to action.