### PR TITLE
Add exec to helm provider

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -247,6 +247,34 @@ func kubernetesResource() *schema.Resource {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_LOAD_CONFIG_FILE", true),
 				Description: "By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disable this behaviour.",
 			},
+			"exec": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"api_version": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"command": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"env": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"args": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+				Description: "",
+			},
 		},
 	}
 }
@@ -336,6 +364,20 @@ func (m *Meta) buildK8sClient(d *schema.ResourceData, terraformVersion string) e
 	}
 	if v, ok := k8sGetOk(d, "client_key"); ok {
 		cfg.KeyData = []byte(v.(string))
+	}
+	if v, ok := k8sGetOk(d, "exec"); ok {
+		exec := &clientcmdapi.ExecConfig{}
+		if spec, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+			exec.APIVersion = spec["api_version"].(string)
+			exec.Command = spec["command"].(string)
+			exec.Args = expandStringSlice(spec["args"].([]interface{}))
+			for kk, vv := range spec["env"].(map[string]interface{}) {
+				exec.Env = append(exec.Env, clientcmdapi.ExecEnvVar{Name: kk, Value: vv.(string)})
+			}
+		} else {
+			return nil, fmt.Errorf("Failed to parse exec")
+		}
+		cfg.ExecProvider = exec
 	}
 
 	m.K8sConfig = cfg

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -274,7 +274,7 @@ func kubernetesResource() *schema.Resource {
 						},
 					},
 				},
-				Description: "",
+				Description: "Use a credential plugin to authenticate.",
 			},
 		},
 	}

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -25,6 +25,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/helm/cmd/helm/installer"
 	"k8s.io/helm/pkg/helm"
 	helm_env "k8s.io/helm/pkg/helm/environment"
@@ -375,7 +376,7 @@ func (m *Meta) buildK8sClient(d *schema.ResourceData, terraformVersion string) e
 				exec.Env = append(exec.Env, clientcmdapi.ExecEnvVar{Name: kk, Value: vv.(string)})
 			}
 		} else {
-			return nil, fmt.Errorf("Failed to parse exec")
+			return fmt.Errorf("Failed to parse exec")
 		}
 		cfg.ExecProvider = exec
 	}
@@ -673,6 +674,19 @@ func getContent(d *schema.ResourceData, key, def string) ([]byte, error) {
 	}
 
 	return []byte(content), nil
+}
+
+func expandStringSlice(s []interface{}) []string {
+	result := make([]string, len(s), len(s))
+	for k, v := range s {
+		// Handle the Terraform parser bug which turns empty strings in lists to nil.
+		if v == nil {
+			result[k] = ""
+		} else {
+			result[k] = v.(string)
+		}
+	}
+	return result
 }
 
 func debug(format string, a ...interface{}) {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -116,3 +116,8 @@ The `kubernetes` block supports:
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disable this behaviour. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
+* `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
+  * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
+  * `command` - (Required) Command to execute.
+  * `args` - (Optional) List of arguments to pass when executing the plugin.
+  * `env` - (Optional) Map of environment variables to set when executing the plugin.


### PR DESCRIPTION
Adding the 'exec' option to the helm provider that is now in the kubernetes provider. This allows us to create kubeconfigs on the fly.