### PR TITLE
Fix loading kubeconfig when disabled

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -291,17 +291,9 @@ func (m *Meta) buildSettings(d *schema.ResourceData) {
 func (m *Meta) buildK8sClient(d *schema.ResourceData, terraformVersion string) error {
 	_, hasStatic := d.GetOk("kubernetes")
 
-	c, err := getK8sConfig(d)
+	cfg, err := getK8sConfig(d)
 	if err != nil {
 		debug("could not get Kubernetes config: %s", err)
-		if !hasStatic {
-			return err
-		}
-	}
-
-	cfg, err := c.ClientConfig()
-	if err != nil {
-		debug("could not get Kubernetes client config: %s", err)
 		if !hasStatic {
 			return err
 		}
@@ -380,9 +372,10 @@ func k8sGet(d *schema.ResourceData, key string) interface{} {
 	return value
 }
 
-func getK8sConfig(d *schema.ResourceData) (clientcmd.ClientConfig, error) {
+func getK8sConfig(d *schema.ResourceData) (*rest.Config, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	overrides := &clientcmd.ConfigOverrides{}
+	path := k8sGet(d, "config_path").(string)
 
 	if !k8sGet(d, "in_cluster").(bool) && k8sGet(d, "load_config_file").(bool) {
 		configPathSplit := strings.Split(k8sGet(d, "config_path").(string), ":")
@@ -403,8 +396,21 @@ func getK8sConfig(d *schema.ResourceData) (clientcmd.ClientConfig, error) {
 		if context != "" {
 			overrides.CurrentContext = context
 		}
+
+		cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+		cfg, err := cc.ClientConfig()
+		if err != nil {
+			if pathErr, ok := err.(*os.PathError); ok && os.IsNotExist(pathErr.Err) {
+				log.Printf("[INFO] Unable to load config file as it doesn't exist at %q", path)
+				return nil, nil
+			}
+			return nil, fmt.Errorf("Failed to load config (%s): %s", path, err)
+		}
+
+		return cfg, nil
 	}
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides), nil
+
+	return nil, nil
 }
 
 // GetHelmClient will return a new Helm client


### PR DESCRIPTION
Fix for #195 

Also requires #304 to work properly.

Because of `clientcmd.NewDefaultClientConfigLoadingRules()` `c.ClientConfig()` was always trying to load kubeconfig from default locations, even if `load_config_file` was set to false. 

I moved all of this under if condition (similar to how its done in kubernetes provider https://github.com/terraform-providers/terraform-provider-kubernetes/blob/master/kubernetes/provider.go#L175) and now it works as expected.