### PR TITLE
Revert "Escape commas in set_string (#227)"

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -27,9 +26,6 @@ import (
 
 // ErrReleaseNotFound is the error when a Helm release is not found
 var ErrReleaseNotFound = errors.New("release not found")
-
-// This is used to escape commas which are not escaped in set_string
-var nonEscapedCommaRegexp = regexp.MustCompile(`([^\\]),`)
 
 func resourceRelease() *schema.Resource {
 	return &schema.Resource{
@@ -583,7 +579,6 @@ func getValues(d *schema.ResourceData) ([]byte, error) {
 
 		name := set["name"].(string)
 		value := set["value"].(string)
-		value = nonEscapedCommaRegexp.ReplaceAllString(value, "$1\\,") // escape any non-escaped commas
 
 		if err := strvals.ParseInto(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			return nil, fmt.Errorf("failed parsing key %q with value %s, %s", name, value, err)
@@ -595,7 +590,6 @@ func getValues(d *schema.ResourceData) ([]byte, error) {
 
 		name := set["name"].(string)
 		value := set["value"].(string)
-		value = nonEscapedCommaRegexp.ReplaceAllString(value, "$1\\,") // escape any non-escaped commas
 
 		if err := strvals.ParseInto(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			return nil, fmt.Errorf("failed parsing key %q with sensitive value, %s", name, err)
@@ -607,7 +601,6 @@ func getValues(d *schema.ResourceData) ([]byte, error) {
 
 		name := set["name"].(string)
 		value := set["value"].(string)
-		value = nonEscapedCommaRegexp.ReplaceAllString(value, "$1\\,") // escape any non-escaped commas
 
 		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			return nil, fmt.Errorf("failed parsing key %q with value %s, %s", name, value, err)

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -141,32 +141,6 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 	})
 }
 
-func TestAccResourceRelease_setStringValues(t *testing.T) {
-	name := fmt.Sprintf("test-set-string-values-%s", acctest.RandString(10))
-	namespace := fmt.Sprintf("%s-%s", testNamespace, acctest.RandString(10))
-	// Delete namespace automatically created by helm after checks
-	defer deleteNamespace(t, namespace)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
-		Steps: []resource.TestStep{{
-			Config: testAccHelmReleaseConfigSetString(testResourceName, namespace, name, "0.6.3", "10.0.0.0/32,10.0.0.1/32,10.0.0.2/32"),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "test: 10.0.0.0/32,10.0.0.1/32,10.0.0.2/32\n"),
-			),
-		}, {
-			Config: testAccHelmReleaseConfigSetString(testResourceName, namespace, name, "0.6.3", "10.0.0.0\\\\/32,10.0.0.1\\\\/32,10.0.0.2\\\\/32"),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "test: 10.0.0.0/32,10.0.0.1/32,10.0.0.2/32\n"),
-			),
-		}},
-	})
-}
-
 func TestAccResourceRelease_updateValues(t *testing.T) {
 	name := fmt.Sprintf("test-update-values-%s", acctest.RandString(10))
 	namespace := fmt.Sprintf("%s-%s", testNamespace, acctest.RandString(10))
@@ -506,23 +480,6 @@ func testAccHelmReleaseConfigBasic(resource, ns, name, version string) string {
 			}
 		}
 	`, resource, name, ns, version)
-}
-
-func testAccHelmReleaseConfigSetString(resource, ns, name, version, value string) string {
-	return fmt.Sprintf(`
-		resource "helm_release" "%s" {
- 			name      = %q
-			namespace = %q
-  			chart     = "stable/mariadb"
-			version   = %q
-
-			set_string {
-				name  = "test"
-				value =  "%s"
-			}
-
-		}
-	`, resource, name, ns, version, value)
 }
 
 func testAccHelmReleaseConfigValues(resource, ns, name, chart string, values []string) string {

--- a/website/docs/release.html.markdown
+++ b/website/docs/release.html.markdown
@@ -77,7 +77,6 @@ The `set`, `set_sensitive` and `set_strings` blocks support:
 * `name` - (Required) full name of the variable to be set.
 * `value` - (Required) value of the variable to be set.
 
-Note: Unlike `--set` in `helm` command, commas in `value` blocks are supported and will not be seen as a new key value set and don't need to be escaped as the provider will do it. This departure from the behaviour of the `helm` command is motivated by the fact that we cannot use a single `set` block for multiple keys in the provider
 
 ## Attributes Reference
 


### PR DESCRIPTION
As it doesn't allow to set list.

This fixes #265

This reverts commit 2b5ad9262638148414c64c54b61d16d6b8f30c5e.