### PR TITLE
Add dependency check for helm_release (#321)

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -329,12 +329,23 @@ func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	values, err := getValues(d)
+	if err != nil {
+		return err
+	}
+
+	config := &chart.Config{Raw: string(values)}
+
 	chart, _, err := getChart(d, m)
 	if err != nil {
 		return err
 	}
 
-	values, err := getValues(d)
+	err = chartutil.ProcessRequirementsEnabled(chart, config)
+	if err != nil {
+		return err
+	}
+	err = chartutil.ProcessRequirementsImportValues(chart)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This uses the upstream chartutil functions to ensure we disable any
dependencies in requirements.yaml before deploying.

Fixes #321 