### PR TITLE
Modernise docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -22,18 +22,18 @@ The Helm provider is used to deploy software packages in Kubernetes. The provide
 
 ```hcl
 resource "helm_release" "mydatabase" {
-    name      = "mydatabase"
-    chart     = "stable/mariadb"
+  name  = "mydatabase"
+  chart = "stable/mariadb"
 
-    set {
-        name  = "mariadbUser"
-        value = "foo"
-    }
+  set {
+    name  = "mariadbUser"
+    value = "foo"
+  }
 
-    set {
-        name = "mariadbPassword"
-        value = "qux"
-    }
+  set {
+    name = "mariadbPassword"
+    value = "qux"
+  }
 }
 ```
 
@@ -52,9 +52,9 @@ The provider always first tries to load **a config file** (usually `$HOME/.kube/
 
 ```hcl
 provider "helm" {
-    kubernetes {
-        config_path = "/path/to/kube_cluster.yaml"
-    }
+  kubernetes {
+    config_path = "/path/to/kube_cluster.yaml"
+  }
 }
 ```
 
@@ -64,15 +64,15 @@ The other way is **statically** define all the credentials:
 
 ```hcl
 provider "helm" {
-    kubernetes {
-        host     = "https://104.196.242.174"
-        username = "ClusterMaster"
-        password = "MindTheGap"
+  kubernetes {
+    host     = "https://104.196.242.174"
+    username = "ClusterMaster"
+    password = "MindTheGap"
 
-        client_certificate     = "${file("~/.kube/client-cert.pem")}"
-        client_key             = "${file("~/.kube/client-key.pem")}"
-        cluster_ca_certificate = "${file("~/.kube/cluster-ca-cert.pem")}"
-    }
+    client_certificate     = "${file("~/.kube/client-cert.pem")}"
+    client_key             = "${file("~/.kube/client-key.pem")}"
+    cluster_ca_certificate = "${file("~/.kube/cluster-ca-cert.pem")}"
+  }
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -31,7 +31,7 @@ resource "helm_release" "mydatabase" {
   }
 
   set {
-    name = "mariadbPassword"
+    name  = "mariadbPassword"
     value = "qux"
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -69,9 +69,9 @@ provider "helm" {
     username = "ClusterMaster"
     password = "MindTheGap"
 
-    client_certificate     = "${file("~/.kube/client-cert.pem")}"
-    client_key             = "${file("~/.kube/client-key.pem")}"
-    cluster_ca_certificate = "${file("~/.kube/cluster-ca-cert.pem")}"
+    client_certificate     = file("~/.kube/client-cert.pem")
+    client_key             = file("~/.kube/client-key.pem")
+    cluster_ca_certificate = file("~/.kube/cluster-ca-cert.pem")
   }
 }
 ```

--- a/website/docs/release.html.markdown
+++ b/website/docs/release.html.markdown
@@ -17,13 +17,13 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 
 ```
 data "helm_repository" "stable" {
-    name = "stable"
-    url  = "https://kubernetes-charts.storage.googleapis.com"
+  name = "stable"
+  url  = "https://kubernetes-charts.storage.googleapis.com"
 }
 
 resource "helm_release" "example" {
   name       = "my-redis-release"
-  repository = "${data.helm_repository.stable.metadata.0.name}"
+  repository = data.helm_repository.stable.metadata[0].name
   chart      = "redis"
   version    = "6.0.1"
 

--- a/website/docs/repository.html.markdown
+++ b/website/docs/repository.html.markdown
@@ -16,14 +16,14 @@ A chart repository is a location where packaged charts can be stored and shared.
 
 ```hcl
 data "helm_repository" "incubator" {
-    name = "incubator"
-    url  = "https://kubernetes-charts-incubator.storage.googleapis.com"
+  name = "incubator"
+  url  = "https://kubernetes-charts-incubator.storage.googleapis.com"
 }
 
 resource "helm_release" "my_cache" {
-    name       = "my-cache"
-    repository = "${data.helm_repository.incubator.metadata.0.name}"
-    chart      = "redis-cache"
+  name       = "my-cache"
+  repository = data.helm_repository.incubator.metadata[0].name
+  chart      = "redis-cache"
 }
 ```
 


### PR DESCRIPTION
* Use 0.12 syntax
* Use two space indentation as suggested by
  https://www.terraform.io/docs/configuration/style.html

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>