### PR TITLE
Use Kubernetes v1.15 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ jobs:
         - sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
         - sudo minikube start --vm-driver=none --kubernetes-version=${KUBERNETES_VERSION}
         - sudo chown -R travis /home/travis/.minikube/
-        - minikube update-context
+        - sudo minikube update-context
+        - mkdir /home/travis/.kube
+        - sudo cp /root/.kube/config /home/travis/.kube/config && chown travis /home/travis/.kube/config
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       script:
         - travis_wait 60 make testacc

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       stage: Acceptance test
       env:
         - CHANGE_MINIKUBE_NONE_USER=true
-        - KUBERNETES_VERSION=v1.10.13
+        - KUBERNETES_VERSION=v1.15.0
       install:
         - sudo apt-get update
         - sudo apt-get install -y socat

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
       env:
         - CHANGE_MINIKUBE_NONE_USER=true
         - KUBERNETES_VERSION=v1.15.4
+        - MINIKUBE_VERSION=v1.4.0
       install:
         - sudo apt-get update
         - sudo apt-get install -y socat
@@ -40,13 +41,11 @@ jobs:
         - sudo mount --make-rshared /
         - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl
         - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 
         - sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
         - sudo minikube start --vm-driver=none --kubernetes-version=${KUBERNETES_VERSION}
         - sudo chown -R travis /home/travis/.minikube/
-        - sudo minikube update-context
-        - mkdir /home/travis/.kube
-        - sudo cp /root/.kube/config /home/travis/.kube/config && chown travis /home/travis/.kube/config
+        - sudo chown -R travis /home/travis/.kube/
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       script:
         - travis_wait 60 make testacc

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       stage: Acceptance test
       env:
         - CHANGE_MINIKUBE_NONE_USER=true
-        - KUBERNETES_VERSION=v1.15.0
+        - KUBERNETES_VERSION=v1.15.4
       install:
         - sudo apt-get update
         - sudo apt-get install -y socat

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 # We need the systemd for the kubeadm and it's default from 16.04+
-dist: xenial
+dist: bionic
 services:
 - docker
 language: go


### PR DESCRIPTION
There are some issues with the acceptance testing however we're behind a few versions of Kubernetes but use the latest minikube.
This also fixes some recent changes made in minikube that change how `update-context` works.