### PR TITLE
Remove the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,42 +11,15 @@ The provider manages the installed [Charts](https://github.com/kubernetes/charts
 Contents
 --------
 
-* [Installation](#installation)
+* [Developing the Provider](#developing-the-provider)
 * [Example](#example)
 * [Documentation](https://www.terraform.io/docs/providers/helm/index.html)
   * [Resource: helm_release](https://www.terraform.io/docs/providers/helm/release.html)
   * [Resource: helm_repository](https://www.terraform.io/docs/providers/helm/repository.html)
 
 
-Installation
+Developing the Provider
 ------------
-
-### Requirements
-
-*terraform-provider-helm* is based on [Terraform](https://www.terraform.io), this means that you need
-
-
-- [Terraform](https://www.terraform.io/downloads.html) >=0.10.0
-- [Kubernetes](https://kubernetes.io/) >=1.4
-
-### Installation from binaries (recommended)
-
-The recommended way to install *terraform-provider-helm* is use the binary
-distributions from the [Releases](https://github.com/terraform-providers/terraform-provider-helm/releases) page. The packages are available for Linux and macOS.
-
-Download and uncompress the latest release for your OS. This example uses the linux binary.
-
-```sh
-> wget https://github.com/terraform-providers/terraform-provider-helm/releases/download/v0.7.0/terraform-provider-helm_v0.7.0_linux_amd64.tar.gz
-> tar -xvf terraform-provider-helm*.tar.gz
-```
-
-Now copy the binary to the Terraform's plugins folder, if is your first plugin maybe isn't present.
-
-```sh
-> mkdir -p ~/.terraform.d/plugins/
-> mv terraform-provider-helm*/terraform-provider-helm ~/.terraform.d/plugins/
-```
 
 ### Installation from sources
 


### PR DESCRIPTION
Since we're official (for a while now) we do not need the manual instructions any longer.
Users should just refer to the official Terraform documentation for installing providers.