### PR TITLE
set connection_timeout parameter

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -78,7 +78,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     60,
-				Description: "Number of seconds Helm will wait to establish a connection to tiller.",
+				Description: "Number of seconds Helm will wait before timing out a connection to tiller.",
 			},
 			"service_account": {
 				Type:        schema.TypeString,

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -77,7 +77,7 @@ func Provider() terraform.ResourceProvider {
 			"connection_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     5,
+				Default:     60,
 				Description: "Number of seconds Helm will wait to establish a connection to tiller.",
 			},
 			"service_account": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 * `init_helm_home` - (Optional) Initialize Helm home directory configured by the `home` attribute if it is not already initialized, defaults to true.
 * `install_tiller` - (Optional) Install Tiller if it is not already installed. Defaults to `true`.
 * `tiller_image` - (Optional) Tiller image to install. Defaults to `gcr.io/kubernetes-helm/tiller:v2.15.1`.
-* `connection_timeout` - (Optional) Number of seconds Helm will wait to establish a connection to tiller. Defaults to `5`.
+* `connection_timeout` - (Optional) Number of seconds Helm will wait before timing out a connection to tiller. Defaults to `60`.
 * `service_account` - (Optional) Service account to install Tiller with. Defaults to `default`.
 * `automount_service_account_token` - (Optional) Auto-mount the given service account to tiller. Defaults to `true`.
 * `override` - (Optional) Override values for the Tiller Deployment manifest. Defaults to `true`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -89,6 +89,7 @@ The following arguments are supported:
 * `init_helm_home` - (Optional) Initialize Helm home directory configured by the `home` attribute if it is not already initialized, defaults to true.
 * `install_tiller` - (Optional) Install Tiller if it is not already installed. Defaults to `true`.
 * `tiller_image` - (Optional) Tiller image to install. Defaults to `gcr.io/kubernetes-helm/tiller:v2.15.1`.
+* `connection_timeout` - (Optional) Number of seconds Helm will wait to establish a connection to tiller. Defaults to `5`.
 * `service_account` - (Optional) Service account to install Tiller with. Defaults to `default`.
 * `automount_service_account_token` - (Optional) Auto-mount the given service account to tiller. Defaults to `true`.
 * `override` - (Optional) Override values for the Tiller Deployment manifest. Defaults to `true`.


### PR DESCRIPTION
As a solution for both #355 and #308, I added a new parameter to set the timeout in seconds to the Helm client.

This PR could be closed in favour of #359 if you think that closing the tunnel each time is the preferred solution