### PR TITLE
Update default value of "reuse" to match with documentation

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -181,7 +181,7 @@ func resourceRelease() *schema.Resource {
 			"reuse": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Default:     true,
 				Description: "Instruct Tiller to re-use an existing name.",
 			},
 			"recreate_pods": {


### PR DESCRIPTION
There is mis-match between default value of `reuse` in `resource_release.go` and its documentation: https://www.terraform.io/docs/providers/helm/release.html#reuse
Another option is update the document https://github.com/terraform-providers/terraform-provider-helm/blob/master/website/docs/r/release.html.markdown to reflect with code.
Feel free to let me know which one it suitable for the provider :).