### PR TITLE
Fix test infra on GKE

### DIFF
--- a/helm/test-infra/gke/main.tf
+++ b/helm/test-infra/gke/main.tf
@@ -37,7 +37,6 @@ resource "google_container_cluster" "primary" {
   name               = "tf-acc-test-${random_id.cluster_name.hex}"
   zone               = "${data.google_compute_zones.available.names[0]}"
   initial_node_count = "${var.workers_count}"
-  node_version       = "${data.google_container_engine_versions.supported.latest_node_version}"
   min_master_version = "${data.google_container_engine_versions.supported.latest_master_version}"
 
   additional_zones = [


### PR DESCRIPTION
This fixes the following error when trying to spin up the test infrastructure:

```
Error: node_version and min_master_version must be set to equivalent values on create
```