### PR TITLE
Make helm_resource.description a computed field

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -300,8 +300,8 @@ func resourceRelease() *schema.Resource {
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Add a custom description",
+				Computed:    true,
+				Description: `Human-friendly "log entry" about the release.`,
 			},
 			"postrender": {
 				Type:        schema.TypeList,
@@ -461,7 +461,6 @@ func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {
 	client.SubNotes = d.Get("render_subchart_notes").(bool)
 	client.DisableOpenAPIValidation = d.Get("disable_openapi_validation").(bool)
 	client.Replace = d.Get("replace").(bool)
-	client.Description = d.Get("description").(string)
 
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
 		pr, err := postrender.NewExec(cmd)
@@ -544,7 +543,6 @@ func resourceReleaseUpdate(d *schema.ResourceData, meta interface{}) error {
 	client.Recreate = d.Get("recreate_pods").(bool)
 	client.MaxHistory = d.Get("max_history").(int)
 	client.CleanupOnFail = d.Get("cleanup_on_fail").(bool)
-	client.Description = d.Get("description").(string)
 
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
 		pr, err := postrender.NewExec(cmd)
@@ -638,6 +636,10 @@ func setIDAndMetadataFromRelease(d *schema.ResourceData, r *release.Release) err
 	}
 
 	if err := d.Set("status", r.Info.Status.String()); err != nil {
+		return err
+	}
+
+	if err := d.Set("description", r.Info.Description); err != nil {
 		return err
 	}
 
@@ -886,7 +888,6 @@ func resourceHelmReleaseImportState(d *schema.ResourceData, meta interface{}) ([
 	}
 
 	d.Set("name", r.Name)
-	d.Set("description", r.Info.Description)
 
 	for key, value := range defaultAttributes {
 		d.Set(key, value)

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -41,7 +41,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", namespace),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-				resource.TestCheckResourceAttr("helm_release.test", "description", "Test"),
+				resource.TestCheckResourceAttr("helm_release.test", "description", "Install complete"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.chart", "mariadb"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "7.1.0"),
 			),
@@ -51,7 +51,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "7.1.0"),
 				resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-				resource.TestCheckResourceAttr("helm_release.test", "description", "Test"),
+				resource.TestCheckResourceAttr("helm_release.test", "description", "Install complete"),
 			),
 		}},
 	})
@@ -609,7 +609,6 @@ func testAccHelmReleaseConfigBasic(resource, ns, name, version string) string {
 		resource "helm_release" "%s" {
  			name        = %q
 			namespace   = %q
-			description = "Test"
 			repository  = "https://kubernetes-charts.storage.googleapis.com"
   			chart       = "mariadb"
 			version     = %q

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -84,7 +84,6 @@ The following arguments are supported:
 * `set_string` - (Optional) Value block with custom STRING values to be merged with the values yaml.
 * `dependency_update` - (Optional) Runs helm dependency update before installing the chart. Defaults to `false`.
 * `replace` - (Optional) Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`.
-* `description` - (Optional) Set release description attribute (visible in the history).
 * `postrender` - (Optional) Configure a command to run after helm renders the manifest which can alter the manifest contents.
 
 The `set`, `set_sensitive` and `set_strings` blocks support:
@@ -102,6 +101,7 @@ The `postrender` block supports a single attribute:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `description` - The human-friendly "log entry" about the release.
 * `metadata` - Block status of the deployed release.
 
 The `metadata` block supports:


### PR DESCRIPTION
After looking into this field some more, it seems that it is set by the helm client itself. There doesn't seem to be a way for an operator to set this field using the `helm` command. e.g [here](https://github.com/helm/helm/blob/357d265de0e72f02c493701cdbee9ecc6eb0a016/pkg/action/uninstall.go#L95)

@relu FYI.