### PR TITLE
Example with chart not in repository

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -99,7 +99,7 @@ func resourceRelease() *schema.Resource {
 			"chart": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Chart name to be installed.",
+				Description: "Chart name to be installed. A path may be used.",
 			},
 			"version": {
 				Type:        schema.TypeString,

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -48,12 +48,23 @@ resource "helm_release" "example" {
 }
 ```
 
+## Example Usage - Local Chart
+
+In case a Chart is not available from a repository, a path may be used:
+
+```hcl
+resource "helm_release" "local" {
+  name       = "my-local-chart"
+  chart      = "./charts/example"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) Release name.
-* `chart` - (Required) Chart name to be installed.
+* `chart` - (Required) Chart name to be installed. A path may be used.
 * `repository` - (Optional) Repository where to locate the requested chart. If is an URL the chart is installed without installing the repository.
 * `repository_key_file` - (Optional) The repositories cert key file
 * `repository_cert_file` - (Optional) The repositories cert file


### PR DESCRIPTION
Hey there!

It took me longer than I'd like to admit to figure out that the Helm provider allows to use a local chart and not just those published in a repo...
So I figured it'd be good to have this documented!

It all started when I wanted to install [Vault via Helm](https://github.com/hashicorp/vault-helm) where there has been an issue since a while asking to publish the chart in a public repo... hashicorp/vault-helm#14 
Of course it'd still be better if that was available in a repository, but it's still good to be able to point to local charts, especially while developing them