### PR TITLE
helm_repository: deprecated

### DIFF
--- a/helm/data_repository.go
+++ b/helm/data_repository.go
@@ -11,6 +11,8 @@ import (
 
 func dataRepository() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will be removed in the next major version.",
+
 		Read: dataRepositoryRead,
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Data Source: helm_repository
 
+!> **Warning:** This resource is deprecated and will be removed in the next major version.
+
 A chart repository is a location where packaged charts can be stored and shared.
 
 `helm_repository` describes a helm repository.
@@ -50,7 +52,3 @@ The `metadata` block supports:
 
 * `name` - Name of the repository read from the home.
 * `url` - URL of the repository read from the home.
-
-## Old resource helm_repository
-
-Before 0.9.0 `helm_repository` was a resource and not a data source. The old resource is now a shim to the data source to preserve backwards compatibility. As the use of the resource is deprecated it is strongly suggested to move to the new data source as the compatibility will be removed in a future release.

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -16,14 +16,9 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 ## Example Usage
 
 ```hcl
-data "helm_repository" "stable" {
-  name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
-}
-
 resource "helm_release" "example" {
   name       = "my-redis-release"
-  repository = data.helm_repository.stable.metadata[0].name
+  repository = "https://kubernetes-charts.storage.googleapis.com" 
   chart      = "redis"
   version    = "6.0.1"
 
@@ -65,12 +60,12 @@ The following arguments are supported:
 
 * `name` - (Required) Release name.
 * `chart` - (Required) Chart name to be installed. A path may be used.
-* `repository` - (Optional) Repository where to locate the requested chart. If is an URL the chart is installed without installing the repository.
+* `repository` - (Optional) Repository URL where to locate the requested chart.
 * `repository_key_file` - (Optional) The repositories cert key file
 * `repository_cert_file` - (Optional) The repositories cert file
 * `repository_ca_file` - (Optional) The Repositories CA File. 
 * `repository_username` - (Optional) Username for HTTP basic authentication against the repository.
-* `repository_password` - (Optional) Password for HTTP basic authentication against the reposotory.
+* `repository_password` - (Optional) Password for HTTP basic authentication against the repository.
 * `devel` - (Optional) Use chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored.
 * `version` - (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
 * `namespace` - (Optional) The namespace to install the release into. Defaults to `default`


### PR DESCRIPTION
### Description

This PR deprecates `helm_repository`, this data source has several problems:
- A Helm repository it's persisted on the client-side, this prevents the configuration be applied from different machines. See https://github.com/terraform-providers/terraform-provider-helm/issues/416
- `helm_repository` modify the state, a data source shouldn't modify the state (by definition).

Since if we remove the capabilities of install the repository on the local machine, the resource results in a POJO, with no value other than host the variables to be reused in the `helm_release` resource.

The suggested new recommended behavior is to use  [`variables`](https://www.terraform.io/docs/configuration/variables.html) to avoid de repetition of the repository URL or any other repository related values. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

Fix https://github.com/terraform-providers/terraform-provider-helm/issues/416
Fix https://github.com/terraform-providers/terraform-provider-helm/issues/335
