### PR TITLE
Metadata should be marked sensitive as it can contain secrets

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -325,6 +325,7 @@ func resourceRelease() *schema.Resource {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Status of the deployed release.",
+				Sensitive:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {


### PR DESCRIPTION
### Description
All values from a helm release are stored in the metadata field. We can mask secrets with `set_sensitive`, but once the values make it into the metadata, they will leak on a diff. Since there is no way to mark an attribute as conditionally sensitive in a terraform schema, we should always assume this field is sensitive.  

Losing the metadata field from diffs, doesn't have any consequence that I can think of. If you are changing the inputs to a release, then those changes are reflected via the  `values`, `set`, and `set_sensitive` blocks. 
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
https://github.com/terraform-providers/terraform-provider-helm/issues/251

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
