### PR TITLE
helm_release: cloak metadata.value and deprecate set_string

### DIFF
--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/float.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/float.go
@@ -1,0 +1,64 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// FloatBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type float64 and is between min and max (inclusive).
+func FloatBetween(min, max float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float64", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%f - %f), got %f", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// FloatAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type float and is at least min (inclusive)
+func FloatAtLeast(min float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%f), got %f", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// FloatAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type float and is at most max (inclusive)
+func FloatAtMost(max float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%f), got %f", k, max, v))
+			return
+		}
+
+		return
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/int.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/int.go
@@ -1,0 +1,125 @@
+package validation
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
+			return warnings, errors
+		}
+
+		if v < min || v > max {
+			errors = append(errors, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return warnings, errors
+		}
+
+		return warnings, errors
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
+			return warnings, errors
+		}
+
+		if v < min {
+			errors = append(errors, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return warnings, errors
+		}
+
+		return warnings, errors
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
+			return warnings, errors
+		}
+
+		if v > max {
+			errors = append(errors, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return warnings, errors
+		}
+
+		return warnings, errors
+	}
+}
+
+// IntDivisibleBy returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is divisible by a given number
+func IntDivisibleBy(divisor int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
+			return warnings, errors
+		}
+
+		if math.Mod(float64(v), float64(divisor)) != 0 {
+			errors = append(errors, fmt.Errorf("expected %s to be divisible by %d, got: %v", k, divisor, i))
+			return warnings, errors
+		}
+
+		return warnings, errors
+	}
+}
+
+// IntInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type int and matches the value of an element in the valid slice
+func IntInSlice(valid []int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
+			return warnings, errors
+		}
+
+		for _, validInt := range valid {
+			if v == validInt {
+				return warnings, errors
+			}
+		}
+
+		errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %d", k, valid, v))
+		return warnings, errors
+	}
+}
+
+// IntNotInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type int and matches the value of an element in the valid slice
+func IntNotInSlice(valid []int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be integer", k))
+			return warnings, errors
+		}
+
+		for _, validInt := range valid {
+			if v == validInt {
+				errors = append(errors, fmt.Errorf("expected %s to not be one of %v, got %d", k, valid, v))
+			}
+		}
+
+		return warnings, errors
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/list.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/list.go
@@ -1,0 +1,41 @@
+package validation
+
+import "fmt"
+
+// ValidateListUniqueStrings is a ValidateFunc that ensures a list has no
+// duplicate items in it. It's useful for when a list is needed over a set
+// because order matters, yet the items still need to be unique.
+//
+// Deprecated: use ListOfUniqueStrings
+func ValidateListUniqueStrings(i interface{}, k string) (warnings []string, errors []error) {
+	return ListOfUniqueStrings(i, k)
+}
+
+// ListOfUniqueStrings is a ValidateFunc that ensures a list has no
+// duplicate items in it. It's useful for when a list is needed over a set
+// because order matters, yet the items still need to be unique.
+func ListOfUniqueStrings(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.([]interface{})
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be List", k))
+		return warnings, errors
+	}
+
+	for _, e := range v {
+		if _, eok := e.(string); !eok {
+			errors = append(errors, fmt.Errorf("expected %q to only contain string elements, found :%v", k, e))
+			return warnings, errors
+		}
+	}
+
+	for n1, i1 := range v {
+		for n2, i2 := range v {
+			if i1.(string) == i2.(string) && n1 != n2 {
+				errors = append(errors, fmt.Errorf("expected %q to not have duplicates: found 2 or more of %v", k, i1))
+				return warnings, errors
+			}
+		}
+	}
+
+	return warnings, errors
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/meta.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/meta.go
@@ -1,0 +1,59 @@
+package validation
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// NoZeroValues is a SchemaValidateFunc which tests if the provided value is
+// not a zero value. It's useful in situations where you want to catch
+// explicit zero values on things like required fields during validation.
+func NoZeroValues(i interface{}, k string) (s []string, es []error) {
+	if reflect.ValueOf(i).Interface() == reflect.Zero(reflect.TypeOf(i)).Interface() {
+		switch reflect.TypeOf(i).Kind() {
+		case reflect.String:
+			es = append(es, fmt.Errorf("%s must not be empty, got %v", k, i))
+		case reflect.Int, reflect.Float64:
+			es = append(es, fmt.Errorf("%s must not be zero, got %v", k, i))
+		default:
+			// this validator should only ever be applied to TypeString, TypeInt and TypeFloat
+			panic(fmt.Errorf("can't use NoZeroValues with %T attribute %s", i, k))
+		}
+	}
+	return
+}
+
+// All returns a SchemaValidateFunc which tests if the provided value
+// passes all provided SchemaValidateFunc
+func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}
+
+// Any returns a SchemaValidateFunc which tests if the provided value
+// passes any of the provided SchemaValidateFunc
+func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			if len(validatorWarnings) == 0 && len(validatorErrors) == 0 {
+				return []string{}, []error{}
+			}
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/network.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/network.go
@@ -1,0 +1,194 @@
+package validation
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// SingleIP returns a SchemaValidateFunc which tests if the provided value
+// is of type string, and in valid single Value notation
+//
+// Deprecated: use IsIPAddress instead
+func SingleIP() schema.SchemaValidateFunc {
+	return IsIPAddress
+}
+
+// IsIPAddress is a SchemaValidateFunc which tests if the provided value is of type string and is a single IP (v4 or v6)
+func IsIPAddress(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	ip := net.ParseIP(v)
+	if ip == nil {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IP, got: %s", k, v))
+	}
+
+	return warnings, errors
+}
+
+// IsIPv6Address is a SchemaValidateFunc which tests if the provided value is of type string and a valid IPv6 address
+func IsIPv6Address(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	ip := net.ParseIP(v)
+	if six := ip.To16(); six == nil {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IPv6 address, got: %s", k, v))
+	}
+
+	return warnings, errors
+}
+
+// IsIPv4Address is a SchemaValidateFunc which tests if the provided value is of type string and a valid IPv4 address
+func IsIPv4Address(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	ip := net.ParseIP(v)
+	if four := ip.To4(); four == nil {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IPv4 address, got: %s", k, v))
+	}
+
+	return warnings, errors
+}
+
+// IPRange returns a SchemaValidateFunc which tests if the provided value is of type string, and in valid IP range
+//
+// Deprecated: use IsIPv4Range instead
+func IPRange() schema.SchemaValidateFunc {
+	return IsIPv4Range
+}
+
+// IsIPv4Range is a SchemaValidateFunc which tests if the provided value is of type string, and in valid IP range
+func IsIPv4Range(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return warnings, errors
+	}
+
+	ips := strings.Split(v, "-")
+	if len(ips) != 2 {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IP range, got: %s", k, v))
+		return warnings, errors
+	}
+
+	ip1 := net.ParseIP(ips[0])
+	ip2 := net.ParseIP(ips[1])
+	if ip1 == nil || ip2 == nil || bytes.Compare(ip1, ip2) > 0 {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IP range, got: %s", k, v))
+	}
+
+	return warnings, errors
+}
+
+// IsCIDR is a SchemaValidateFunc which tests if the provided value is of type string and a valid CIDR
+func IsCIDR(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return warnings, errors
+	}
+
+	if _, _, err := net.ParseCIDR(v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid IPv4 Value, got %v: %v", k, i, err))
+	}
+
+	return warnings, errors
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid Value network notation, and has significant bits between min and max (inclusive)
+//
+// Deprecated: use IsCIDRNetwork instead
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return IsCIDRNetwork(min, max)
+}
+
+// IsCIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid Value network notation, and has significant bits between min and max (inclusive)
+func IsCIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("expected %s to contain a valid Value, got: %s with err: %s", k, v, err))
+			return warnings, errors
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			errors = append(errors, fmt.Errorf("expected %s to contain a valid network Value, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			errors = append(errors, fmt.Errorf("expected %q to contain a network Value with between %d and %d significant bits, got: %d", k, min, max, sigbits))
+		}
+
+		return warnings, errors
+	}
+}
+
+// IsMACAddress is a SchemaValidateFunc which tests if the provided value is of type string and a valid MAC address
+func IsMACAddress(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := net.ParseMAC(v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid MAC address, got %v: %v", k, i, err))
+	}
+
+	return warnings, errors
+}
+
+// IsPortNumber is a SchemaValidateFunc which tests if the provided value is of type string and a valid TCP Port Number
+func IsPortNumber(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(int)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be integer", k))
+		return warnings, errors
+	}
+
+	if 1 > v || v > 65535 {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid port number, got: %v", k, v))
+	}
+
+	return warnings, errors
+}
+
+// IsPortNumberOrZero is a SchemaValidateFunc which tests if the provided value is of type string and a valid TCP Port Number or zero
+func IsPortNumberOrZero(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(int)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be integer", k))
+		return warnings, errors
+	}
+
+	if 0 > v || v > 65535 {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid port number or 0, got: %v", k, v))
+	}
+
+	return warnings, errors
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/strings.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/strings.go
@@ -1,0 +1,231 @@
+package validation
+
+import (
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+)
+
+// StringIsNotEmpty is a ValidateFunc that ensures a string is not empty
+func StringIsNotEmpty(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if v == "" {
+		return nil, []error{fmt.Errorf("expected %q to not be an empty string, got %v", k, i)}
+	}
+
+	return nil, nil
+}
+
+// StringIsNotWhiteSpace is a ValidateFunc that ensures a string is not empty or consisting entirely of whitespace characters
+func StringIsNotWhiteSpace(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if strings.TrimSpace(v) == "" {
+		return nil, []error{fmt.Errorf("expected %q to not be an empty string or whitespace", k)}
+	}
+
+	return nil, nil
+}
+
+// StringIsEmpty is a ValidateFunc that ensures a string has no characters
+func StringIsEmpty(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if v != "" {
+		return nil, []error{fmt.Errorf("expected %q to be an empty string: got %v", k, v)}
+	}
+
+	return nil, nil
+}
+
+// StringIsWhiteSpace is a ValidateFunc that ensures a string is composed of entirely whitespace
+func StringIsWhiteSpace(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if strings.TrimSpace(v) != "" {
+		return nil, []error{fmt.Errorf("expected %q to be an empty string or whitespace: got %v", k, v)}
+	}
+
+	return nil, nil
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		if len(v) < min || len(v) > max {
+			errors = append(errors, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+
+		return warnings, errors
+	}
+}
+
+// StringMatch returns a SchemaValidateFunc which tests if the provided value
+// matches a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must match some globby regexp".
+func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); !ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to match regular expression %q, got %v", k, r, i)}
+		}
+		return nil, nil
+	}
+}
+
+// StringDoesNotMatch returns a SchemaValidateFunc which tests if the provided value
+// does not match a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must not match some globby regexp".
+func StringDoesNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to not match regular expression %q, got %v", k, r, i)}
+		}
+		return nil, nil
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return warnings, errors
+			}
+		}
+
+		errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return warnings, errors
+	}
+}
+
+// StringDoesNotContainAny returns a SchemaValidateFunc which validates that the
+// provided value does not contain any of the specified Unicode code points in chars.
+func StringDoesNotContainAny(chars string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		if strings.ContainsAny(v, chars) {
+			errors = append(errors, fmt.Errorf("expected value of %s to not contain any of %q, got %v", k, chars, i))
+			return warnings, errors
+		}
+
+		return warnings, errors
+	}
+}
+
+// StringIsBase64 is a ValidateFunc that ensures a string can be parsed as Base64
+func StringIsBase64(i interface{}, k string) (warnings []string, errors []error) {
+	// Empty string is not allowed
+	if warnings, errors = StringIsNotEmpty(i, k); len(errors) > 0 {
+		return
+	}
+
+	// NoEmptyStrings checks it is a string
+	v, _ := i.(string)
+
+	if _, err := base64.StdEncoding.DecodeString(v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a base64 string, got %v", k, v))
+	}
+
+	return warnings, errors
+}
+
+// ValidateJsonString is a SchemaValidateFunc which tests to make sure the
+// supplied string is valid JSON.
+//
+// Deprecated: use StringIsJSON instead
+func ValidateJsonString(i interface{}, k string) (warnings []string, errors []error) {
+	return StringIsJSON(i, k)
+}
+
+// StringIsJSON is a SchemaValidateFunc which tests to make sure the supplied string is valid JSON.
+func StringIsJSON(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+
+	return warnings, errors
+}
+
+// ValidateRegexp returns a SchemaValidateFunc which tests to make sure the
+// supplied string is a valid regular expression.
+//
+// Deprecated: use StringIsValidRegExp instead
+func ValidateRegexp(i interface{}, k string) (warnings []string, errors []error) {
+	return StringIsValidRegExp(i, k)
+}
+
+// StringIsValidRegExp returns a SchemaValidateFunc which tests to make sure the supplied string is a valid regular expression.
+func StringIsValidRegExp(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := regexp.Compile(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+
+	return warnings, errors
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/testing.go
@@ -1,0 +1,43 @@
+package validation
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+type testCase struct {
+	val         interface{}
+	f           schema.SchemaValidateFunc
+	expectedErr *regexp.Regexp
+}
+
+func runTestCases(t *testing.T, cases []testCase) {
+	matchErr := func(errs []error, r *regexp.Regexp) bool {
+		// err must match one provided
+		for _, err := range errs {
+			if r.MatchString(err.Error()) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for i, tc := range cases {
+		_, errs := tc.f(tc.val, "test_property")
+
+		if len(errs) == 0 && tc.expectedErr == nil {
+			continue
+		}
+
+		if len(errs) != 0 && tc.expectedErr == nil {
+			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
+		}
+
+		if !matchErr(errs, tc.expectedErr) {
+			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/time.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/time.go
@@ -1,0 +1,61 @@
+package validation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// IsDayOfTheWeek id a SchemaValidateFunc which tests if the provided value is of type string and a valid english day of the week
+func IsDayOfTheWeek(ignoreCase bool) schema.SchemaValidateFunc {
+	return StringInSlice([]string{
+		"Monday",
+		"Tuesday",
+		"Wednesday",
+		"Thursday",
+		"Friday",
+		"Saturday",
+		"Sunday",
+	}, ignoreCase)
+}
+
+// IsMonth id a SchemaValidateFunc which tests if the provided value is of type string and a valid english month
+func IsMonth(ignoreCase bool) schema.SchemaValidateFunc {
+	return StringInSlice([]string{
+		"January",
+		"February",
+		"March",
+		"April",
+		"May",
+		"June",
+		"July",
+		"August",
+		"September",
+		"October",
+		"November",
+		"December",
+	}, ignoreCase)
+}
+
+// IsRFC3339Time is a SchemaValidateFunc which tests if the provided value is of type string and a valid RFC33349Time
+func IsRFC3339Time(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := time.Parse(time.RFC3339, v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid RFC3339 date, got %q: %+v", k, i, err))
+	}
+
+	return warnings, errors
+}
+
+// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses as time.RFC3339 format
+//
+// Deprecated: use IsRFC3339Time() instead
+func ValidateRFC3339TimeString(i interface{}, k string) (warnings []string, errors []error) {
+	return IsRFC3339Time(i, k)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/uuid.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/uuid.go
@@ -1,0 +1,22 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+// IsUUID is a ValidateFunc that ensures a string can be parsed as UUID
+func IsUUID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := uuid.ParseUUID(v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid UUID, got %v", k, v))
+	}
+
+	return warnings, errors
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/web.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/validation/web.go
@@ -1,0 +1,55 @@
+package validation
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// IsURLWithHTTPS is a SchemaValidateFunc which tests if the provided value is of type string and a valid HTTPS URL
+func IsURLWithHTTPS(i interface{}, k string) (_ []string, errors []error) {
+	return IsURLWithScheme([]string{"https"})(i, k)
+}
+
+// IsURLWithHTTPorHTTPS is a SchemaValidateFunc which tests if the provided value is of type string and a valid HTTP or HTTPS URL
+func IsURLWithHTTPorHTTPS(i interface{}, k string) (_ []string, errors []error) {
+	return IsURLWithScheme([]string{"http", "https"})(i, k)
+}
+
+// IsURLWithScheme is a SchemaValidateFunc which tests if the provided value is of type string and a valid URL with the provided schemas
+func IsURLWithScheme(validSchemes []string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (_ []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+			return
+		}
+
+		if v == "" {
+			errors = append(errors, fmt.Errorf("expected %q url to not be empty, got %v", k, i))
+			return
+		}
+
+		u, err := url.Parse(v)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("expected %q to be a valid url, got %v: %+v", k, v, err))
+			return
+		}
+
+		if u.Host == "" {
+			errors = append(errors, fmt.Errorf("expected %q to have a host, got %v", k, v))
+			return
+		}
+
+		for _, s := range validSchemes {
+			if u.Scheme == s {
+				return //last check so just return
+			}
+		}
+
+		errors = append(errors, fmt.Errorf("expected %q to have a url with schema of: %q, got %v", k, strings.Join(validSchemes, ","), v))
+		return
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -328,6 +328,8 @@ github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
 github.com/hashicorp/terraform-plugin-sdk/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/helper/resource
 github.com/hashicorp/terraform-plugin-sdk/helper/schema
+github.com/hashicorp/terraform-plugin-sdk/helper/structure
+github.com/hashicorp/terraform-plugin-sdk/helper/validation
 github.com/hashicorp/terraform-plugin-sdk/httpclient
 github.com/hashicorp/terraform-plugin-sdk/internal/addrs
 github.com/hashicorp/terraform-plugin-sdk/internal/command/format


### PR DESCRIPTION
### Description

#### Sensitive data leacks

The problems exposed at #424 are fixed cloaking the values the `metadata.0.values` searching the values defined by `set_sensitive` arguments and replacing it with `(sensistive_value)`. 

```      
     metadata = [
            {
                chart     = "podinfo"
                name      = "podinfo"
                namespace = "test-providers"
                revision  = 1
                values    = jsonencode(
                    {
                        replicaCount = 1
                        service      = {
                            password = "(sensitive value)"
                        }
                    }
                )
                version   = "3.2.2"
            },
     ]
```

This is replaced inside of the provider, and not just simply turning the `values` attribute into a sensitive value. I tried to add a `values_raw` with the original data and mark this as sensitive but didn't work, it looks like terraform was ignoring this and just displaying the values. 

####  `set_string` deprecation

`set_string` it's a very ad-hoc argument, implemented in a way that simply doesn't scale. `set_sensitive` was missing the functionality of `string` so following the pattern we should introduce `set_sensitive_string` what it's simply horrible.

Instead of doing this `set_string` has been deprecated in favor of `set` with the option `type` equal to `string`, behaves exactly as `set_string`. Additionally now `set_sensitive` also has the functionally as string. 

```
  set_sensitive {
    name  = "very-secret-number"
    value = 42
    type = "string"
  }
```

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
Fixes #424 
Closes #473
Closes #340
