### PR TITLE
Update 'helm_release' resource docs for optional "type" parameter

### DIFF
--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -94,7 +94,13 @@ The following arguments are supported:
 * `postrender` - (Optional) Configure a command to run after helm renders the manifest which can alter the manifest contents.
 * `create_namespace` - (Optional) Create the namespace if it does not yet exist. Defaults to `false`.
 
-The `set`, `set_sensitive` and `set_strings` blocks support:
+The `set` and `set_sensitive` blocks support:
+
+* `name` - (Required) full name of the variable to be set.
+* `value` - (Required) value of the variable to be set.
+* `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
+
+The `set_strings` block supports:
 
 * `name` - (Required) full name of the variable to be set.
 * `value` - (Required) value of the variable to be set.


### PR DESCRIPTION
### Description
I stumbled upon this today when receiving a deprecation warning about the 'set_string' block on the latest provider version. It suggested using the 'set' block with the 'type' parameter set to 'string'. That optional parameter is not currently documented, but was verified via the source code, and it indeed worked. This PR updates the documentation so it is made aware the 'type' parameter is optional in the 'set' and 'set_sensitive' blocks.

### Acceptance tests
```
$ make website
# Visit http://127.0.0.1:4567/docs/providers/helm/r/release.html
```
### References
https://github.com/terraform-providers/terraform-provider-helm/blob/master/helm/resource_release.go#L140

