### PR TITLE
fix: avoid concurrent read/write in metadata (#494)

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -311,15 +311,15 @@ func expandStringSlice(s []interface{}) []string {
 func (m *Meta) GetHelmConfiguration(namespace string) (*action.Configuration, error) {
 	m.Lock()
 	defer m.Unlock()
-
+	debug("[INFO] GetHelmConfiguration start")
 	actionConfig := new(action.Configuration)
 
-	kc := &KubeConfig{ConfigData: m.data, Namespace: &namespace}
+	kc := newKubeConfig(m.data, &namespace)
 
 	if err := actionConfig.Init(kc, namespace, m.HelmDriver, debug); err != nil {
 		return nil, err
 	}
-
+	debug("[INFO] GetHelmConfiguration success")
 	return actionConfig, nil
 }
 

--- a/helm/test-fixtures/charts/basic-chart/Chart.yaml
+++ b/helm/test-fixtures/charts/basic-chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: basic-chart
+description: Basic chart which simply creates a config map with direct passthrough of all values to values in CM.
+
+type: application
+
+version: 0.1.0
+appVersion: 0.1.0

--- a/helm/test-fixtures/charts/basic-chart/templates/configmap.yaml
+++ b/helm/test-fixtures/charts/basic-chart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+data:
+  {{- .Values | toYaml | nindent 2 }}


### PR DESCRIPTION
### Description
After debugging and collecting info on #494, I made a noticable change in the way Kubernetes config is loaded. This change is required to avoid `concurrent map read and write` errors. While reading readource data from `Meta` object, Helm Provider did use locking, but on `KubeConfig` and not on `Meta` object itself. This caused the error. I guess this PR might've been smaller if I used locking on `Meta` in `ToRawKubeConfigLoader` function. However we have no access to `Meta` there and I wanted to keep `KubeConfig` structure as small and independent as possible. 

Possible downsides: I probably decreased the performance of Helm Provider - there's no caching of client.
Possible solution (my guess): add a `map[string]*action.Configuration` to `Meta` and cache Helm configuration per each namespace?

* Fix: Looks like rewriting code related to Helm configuration creation (Kubeconfig structure) does the trick - I'm not sure of performance and memory consumption implications though
* Improvement: Use `logId` to log out more details (function and name of resource) when running with `TF_LOG=DEBUG` environmental variable
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

You can see the test log for this PR here: https://gist.github.com/krzysztof-miemiec/5f2fd076171dc584af9b5c1b7beb389d

Previously there was no acceptance test which checked simultaneous deployment of multiple resources at the same time. I added a test case for that. To make things fast and simple, I added a chart fixture containing a simple `ConfigMap` deployment. 

I also ran my new test against the old codebase, getting `fatal error: concurrent map read and map write` 8 out of 10 attempts. I don't know how to reproduce it 10/10 times, but the test behaves like just like real-world scenario. After changes in this PR, the test passes 10/10 times.

Sidenote: I run tests on Docker Desktop on Mac w/ Kubernetes enabled. Tests take a lot of time and fail if you have poor Internet connection - is it necessary to pull external charts like MariaDB?

### References
- fixes #494 
- probably also fixes #493
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
