### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Terraform Provider for Helm
-[![Actions Status](https://github.com/terraform-providers/terraform-provider-helm/workflows/tests/badge.svg)](https://github.com/hashicorp/terraform-provider-helm/actions)
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hashicorp/terraform-provider-helm?label=release)](https://github.com/terraform-providers/terraform-provider-helm/releases)
+[![Actions Status](https://github.com/hashicorp/terraform-provider-helm/workflows/tests/badge.svg)](https://github.com/hashicorp/terraform-provider-helm/actions)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hashicorp/terraform-provider-helm?label=release)](https://github.com/hashicorp/terraform-provider-helm/releases)
 [![license](https://img.shields.io/github/license/hashicorp/terraform-provider-helm.svg)]()
 [![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/terraform-provider-helm)](https://goreportcard.com/report/github.com/hashicorp/terraform-provider-helm)
 ===========================

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -15,17 +15,17 @@ To learn more about how to create issues and pull requests in this repository, a
 
 If you wish to compile the provider from source code, you'll first need [Go](http://www.golang.org) installed on your machine (version >=1.14 is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-helm`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-helm`
 
 ```sh
-> mkdir -p $GOPATH/src/github.com/terraform-providers
-> git clone https://github.com/terraform-providers/terraform-provider-helm.git $GOPATH/src/github.com/terraform-providers/terraform-provider-helm
+> mkdir -p $GOPATH/src/github.com/hashicorp
+> git clone https://github.com/hashicorp/terraform-provider-helm.git $GOPATH/src/github.com/hashicorp/terraform-provider-helm
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-> cd $GOPATH/src/github.com/terraform-providers/terraform-provider-helm
+> cd $GOPATH/src/github.com/hashicorp/terraform-provider-helm
 > make build
 ```
 

--- a/_about/ISSUES.md
+++ b/_about/ISSUES.md
@@ -5,7 +5,7 @@
 We welcome your feature requests and bug reports. Below you'll find short checklists with guidelines for well-formed
 issues of each type.
 
-### [Bug Reports](https://github.com/terraform-providers/terraform-provider-helm/issues/new/choose)
+### [Bug Reports](https://github.com/hashicorp/terraform-provider-helm/issues/new/choose)
 
  - [ ] __Test against the latest release__: Make sure you test against the latest
    released version. It is possible we already fixed the bug you're experiencing.
@@ -13,7 +13,7 @@ issues of each type.
  - [ ] __Search for possible duplicate reports__: It's helpful to keep bug
    reports consolidated to one thread, so do a quick search on existing bug
    reports to check if anybody else has reported the same thing. You can [scope
-      searches by the label "bug"](https://github.com/terraform-providers/terraform-provider-helm/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to help narrow things down.
+      searches by the label "bug"](https://github.com/hashicorp/terraform-provider-helm/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to help narrow things down.
 
  - [ ] __Include steps to reproduce__: Provide steps to reproduce the issue,
    along with your `.tf` files, with secrets removed, so we can try to
@@ -23,12 +23,12 @@ issues of each type.
    create a [gist](https://gist.github.com) of the *entire* generated crash log
    for us to look at. Double check no sensitive items were in the log.
 
-### [Feature Requests](https://github.com/terraform-providers/terraform-provider-helm/issues/new/choose)
+### [Feature Requests](https://github.com/hashicorp/terraform-provider-helm/issues/new/choose)
 
  - [ ] __Search for possible duplicate requests__: It's helpful to keep requests
    consolidated to one thread, so do a quick search on existing requests to
    check if anybody else has reported the same thing. You can [scope searches by
-      the label "enhancement"](https://github.com/terraform-providers/terraform-provider-helm/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to help narrow things down.
+      the label "enhancement"](https://github.com/hashicorp/terraform-provider-helm/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to help narrow things down.
 
  - [ ] __Include a use case description__: In addition to describing the
    behavior of the feature you'd like to see added, it's helpful to also lay

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-helm
+module github.com/hashicorp/terraform-provider-helm
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-helm/helm"
+	"github.com/hashicorp/terraform-provider-helm/helm"
 )
 
 func main() {


### PR DESCRIPTION
`terraform-provider-helm` has been moved to the `hashicorp`
organization.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
