### PR TITLE
Added app_version to metadata attribute block

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -383,6 +383,11 @@ func resourceRelease() *schema.Resource {
 							Computed:    true,
 							Description: "A SemVer 2 conformant version string of the chart.",
 						},
+						"app_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version number of the application being deployed.",
+						},
 						"values": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -691,12 +696,13 @@ func setIDAndMetadataFromRelease(d *schema.ResourceData, r *release.Release) err
 	}
 
 	return d.Set("metadata", []map[string]interface{}{{
-		"name":      r.Name,
-		"revision":  r.Version,
-		"namespace": r.Namespace,
-		"chart":     r.Chart.Metadata.Name,
-		"version":   r.Chart.Metadata.Version,
-		"values":    string(values),
+		"name":        r.Name,
+		"revision":    r.Version,
+		"namespace":   r.Namespace,
+		"chart":       r.Chart.Metadata.Name,
+		"version":     r.Chart.Metadata.Version,
+		"app_version": r.Chart.Metadata.AppVersion,
+		"values":      string(values),
 	}})
 }
 

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -45,6 +45,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("helm_release.test", "description", "Test"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.chart", "mariadb"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "7.1.0"),
+				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.app_version", "10.3.20"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigBasic(testResourceName, namespace, name, "7.1.0"),

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -120,6 +120,7 @@ The `metadata` block supports:
 * `revision` - Version is an int32 which represents the version of the release.
 * `status` - Status of the release.
 * `version` - A SemVer 2 conformant version string of the chart.
+* `app_version` - The version number of the application being deployed.
 * `values` - The compounded values from `values` and `set*` attributes.
 
 ## Import


### PR DESCRIPTION
### Description

Added chart's appVersion to metadata attribute block as per  #531 (which I opened 😅)
You can see the test gist [here](https://gist.github.com/guyzyl/f5b8e2634fb661f07c2c1791b8f89a0b).

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)