### PR TITLE
Add in_cluster_config attribute to provider block

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -91,6 +91,7 @@ The following arguments are supported:
 The `kubernetes` block supports:
 
 * `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG_PATH`.
+* `in_cluster_config` - (Optional) Use the in-cluster configuration when running Terraform inside Kubernetes.
 * `host` - (Optional) The hostname (in form of URI) of Kubernetes master. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_USER`.
 * `password` - (Optional) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_PASSWORD`.


### PR DESCRIPTION
### Description

This PR adds the `in_cluster_config` field to the provider block, allowing the provider to be run inside Kubernetes.

### Acceptance tests
- [ ] ~Have you added an acceptance test for the functionality being added?~
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

See GitHub Action.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `in_cluster_config` to provider block.
```
### References

https://github.com/helm/helm/issues/7430

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
