### PR TITLE
Remove set_string attribute from helm_release

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -176,25 +176,6 @@ func resourceRelease() *schema.Resource {
 					},
 				},
 			},
-			"set_string": {
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Description: "Custom string values to be merged with the values.",
-				Deprecated: "This argument is deprecated and will be removed in the next major" +
-					" version. Use `set` argument with `type` equals to `string`",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"value": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
 			"namespace": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -893,17 +874,6 @@ func getValues(d resourceGetter) (map[string]interface{}, error) {
 		set := raw.(map[string]interface{})
 		if err := getValue(base, set); err != nil {
 			return nil, err
-		}
-	}
-
-	for _, raw := range d.Get("set_string").(*schema.Set).List() {
-		set := raw.(map[string]interface{})
-
-		name := set["name"].(string)
-		value := set["value"].(string)
-
-		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
-			return nil, fmt.Errorf("failed parsing key %q with value %s, %s", name, value, err)
 		}
 	}
 

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -36,9 +36,10 @@ resource "helm_release" "example" {
     value = "true"
   }
 
-  set_string {
+  set {
     name  = "service.annotations.prometheus\\.io/port"
     value = "9127"
+    type  = "string"
   }
 }
 ```
@@ -98,7 +99,6 @@ The following arguments are supported:
 * `values` - (Optional) List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options.
 * `set` - (Optional) Value block with custom values to be merged with the values yaml.
 * `set_sensitive` - (Optional) Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff.
-* `set_string` - (Optional) Value block with custom STRING values to be merged with the values yaml.
 * `dependency_update` - (Optional) Runs helm dependency update before installing the chart. Defaults to `false`.
 * `replace` - (Optional) Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`.
 * `description` - (Optional) Set release description attribute (visible in the history).
@@ -111,11 +111,6 @@ The `set` and `set_sensitive` blocks support:
 * `name` - (Required) full name of the variable to be set.
 * `value` - (Required) value of the variable to be set.
 * `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
-
-The `set_strings` block supports:
-
-* `name` - (Required) full name of the variable to be set.
-* `value` - (Required) value of the variable to be set.
 
 The `postrender` block supports a single attribute:
 


### PR DESCRIPTION
### Description

Removes the `set_string` attribute from helm_release, which has been deprecated in favour of `set`.

### Acceptance tests
- [ ] ~Have you added an acceptance test for the functionality being added?~
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

See GitHub Action output.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Remove `set_string` attribute 
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
