### PR TITLE
Add values_sensitive option to set sensitive values as yaml

### DIFF
--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -97,6 +97,7 @@ The following arguments are supported:
 * `disable_openapi_validation` - (Optional) If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 * `wait` - (Optional) Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`.
 * `values` - (Optional) List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options.
+* `values_sensitive` - (Optional) List of sensitive values in raw yaml to pass to helm. Sensitive values will be merged, in order, as Helm does with multiple `-f` options. Sensitive values won't be exposed in the plan's diff.
 * `set` - (Optional) Value block with custom values to be merged with the values yaml.
 * `set_sensitive` - (Optional) Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff.
 * `dependency_update` - (Optional) Runs helm dependency update before installing the chart. Defaults to `false`.


### PR DESCRIPTION
### Description

When using tools like [sops](https://github.com/mozilla/sops) or similar, multiple secrets are often managed in a single Yaml file. It's not possible to pass it using `set_sensitive`. This PR implements `values_sensitive` argument, which works just as `values`, but hides its content just as `set_sensitive`.

The PR includes tests and documentation, and closes #546.

Note: after implementing it, I realized it duplicates with PR #549 .

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=[Cc]loak'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run=[Cc]loak -timeout 120m -parallel=4
=== RUN   TestAccResourceRelease_cloakValues
=== PAUSE TestAccResourceRelease_cloakValues
=== RUN   TestAccResourceRelease_cloakValuesYaml
=== PAUSE TestAccResourceRelease_cloakValuesYaml
=== RUN   TestCloakSetValuesYaml
--- PASS: TestCloakSetValuesYaml (0.00s)
=== RUN   TestCloakSetValuesYamlNotMatching
--- PASS: TestCloakSetValuesYamlNotMatching (0.00s)
=== RUN   TestCloakSetValues
--- PASS: TestCloakSetValues (0.00s)
=== RUN   TestCloakSetValuesNested
--- PASS: TestCloakSetValuesNested (0.00s)
=== RUN   TestCloakSetValuesNotMatching
--- PASS: TestCloakSetValuesNotMatching (0.00s)
=== CONT  TestAccResourceRelease_cloakValues
=== CONT  TestAccResourceRelease_cloakValuesYaml
    provider_test.go:162: [DEBUG] Creating namespace terraform-acc-test-3xbfya6mvh
=== CONT  TestAccResourceRelease_cloakValues
    provider_test.go:162: [DEBUG] Creating namespace terraform-acc-test-ovemsbqlx3
--- PASS: TestAccResourceRelease_cloakValues (21.99s)
--- PASS: TestAccResourceRelease_cloakValuesYaml (24.82s)
PASS
ok      github.com/hashicorp/terraform-provider-helm/helm       24.970s
```

### Release Note

```release-note
- Adds `values_sensitive` option to set sensitive values as yaml
```

### References

Resolves #546 
Supersedes #549

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment