### PR TITLE
Add config_paths to kubernetes block in provider config

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -225,9 +225,18 @@ func kubernetesResource() *schema.Resource {
 	}
 }
 
+var apiTokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+
 func inCluster() bool {
 	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
-	return host != "" && port != ""
+	if host == "" || port == "" {
+		return false
+	}
+
+	if _, err := os.Stat(apiTokenMountPath); err != nil {
+		return false
+	}
+	return true
 }
 
 var authDocumentationURL = "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication"

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -239,7 +239,7 @@ func inCluster() bool {
 	return true
 }
 
-var authDocumentationURL = "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication"
+var authDocumentationURL = "https://registry.terraform.io/providers/hashicorp/helm/latest/docs#authentication"
 
 func checkKubernetesConfigurationValid(d *schema.ResourceData) error {
 	if inCluster() {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,6 +17,12 @@ The Helm provider is used to deploy software packages in Kubernetes. The provide
 ## Example Usage
 
 ```hcl
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
 resource "helm_release" "mydatabase" {
   name  = "mydatabase"
   chart = "stable/mariadb"
@@ -91,6 +97,7 @@ The following arguments are supported:
 The `kubernetes` block supports:
 
 * `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG_PATH`.
+* `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`.
 * `host` - (Optional) The hostname (in form of URI) of Kubernetes master. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_USER`.
 * `password` - (Optional) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_PASSWORD`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -88,6 +88,11 @@ provider "helm" {
 }
 ```
 
+### In-cluster Configuration
+
+The provider is able to detect when it is running inside a cluster, so in this case you do not need to specify any configuration options in the provider block.
+
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,46 +23,56 @@ provider "helm" {
   }
 }
 
-resource "helm_release" "mydatabase" {
-  name  = "mydatabase"
-  chart = "stable/mariadb"
+resource "helm_release" "nginx_ingress" {
+  name       = "nginx-ingress-controller"
+
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx-ingress-controller"
 
   set {
-    name  = "mariadbUser"
-    value = "foo"
-  }
-
-  set {
-    name  = "mariadbPassword"
-    value = "qux"
+    name  = "service.type"
+    value = "ClusterIP"
   }
 }
 ```
 
 ## Requirements
 
-- You must have a Kubernetes cluster available. We recommend version 1.11.0 or higher.
+- You must have a Kubernetes cluster available. We recommend version 1.14.0 or higher.
 - You should also have a local configured copy of kubectl.
 
 ## Authentication
 
-There are generally two ways to configure the Helm provider.
+The provider must be explicitly configured either using the provider block or using environment variables. There are two ways to configure the Helm provider.
 
 ### File config
 
-The provider always first tries to load **a config file** (usually `$HOME/.kube/config`), for access kubernetes and reads all the Helm files from home (usually `$HOME/.helm`). You can also define that file with the following setting:
+The easiest way is to supply a path to your kubeconfig file using the `config_path` attribute or using the `KUBE_CONFIG_PATH` environment variable.
 
 ```hcl
 provider "helm" {
   kubernetes {
-    config_path = "/path/to/kube_cluster.yaml"
+    config_path = "~/.kube/config"
+  }
+}
+```
+
+The provider also supports multiple paths in the same way that kubectl does.
+
+```hcl
+provider "helm" {
+  kubernetes {
+    config_paths = [
+      "/path/to/config_a.yaml",
+      "/path/to/config_b.yaml"
+    ]
   }
 }
 ```
 
 ### Statically defined credentials
 
-The other way is **statically** define all the credentials:
+You can also **statically** define all the credentials:
 
 ```hcl
 provider "helm" {
@@ -77,9 +87,6 @@ provider "helm" {
   }
 }
 ```
-
-If you have **both** valid configuration in a config file and static configuration, the static one is used as override.
-i.e. any static field will override its counterpart loaded from the config.
 
 ## Argument Reference
 

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -9,6 +9,7 @@ description: |-
 # Resource: helm_release
 
 A Release is an instance of a chart running in a Kubernetes cluster.
+
 A Chart is a Helm package. It contains all of the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster.
 
 `helm_release` describes the desired status of a chart in a kubernetes cluster.
@@ -18,7 +19,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 ```hcl
 resource "helm_release" "example" {
   name       = "my-redis-release"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://charts.bitnami.com/bitnami"
   chart      = "redis"
   version    = "6.0.1"
 
@@ -63,6 +64,20 @@ An absolute URL to the .tgz of the Chart may also be used:
 resource "helm_release" "example" {
   name  = "redis"
   chart = "https://charts.bitnami.com/bitnami/redis-10.7.16.tgz"
+}
+```
+
+## Example Usage - Chart Repository configured outside of Terraform
+
+The provider also supports repositories that are added to the local machine outside of Terraform by running `helm repo add`
+
+```hcl
+
+# run this first: `helm repo add bitnami https://charts.bitnami.com/bitnami`
+
+resource "helm_release" "example" {
+  name  = "redis"
+  chart = "bitnami/redis"
 }
 ```
 


### PR DESCRIPTION
### Description

This PR adds the `config_paths` attribute to the kubernetes section of the provider block.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

edit: acceptance tests are fixed, see github actions output

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add config_paths attribute to the kubernetes section of the provider block
```
### References

https://github.com/hashicorp/terraform-provider-kubernetes/pull/1052

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
