### PR TITLE
Set up matrix build to run acc tests against different tf versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
     - master
 
 jobs:
-  kind:
+  unit_test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -18,7 +18,19 @@ jobs:
       run: |
         make test
         make vet
-    - uses: engineerd/setup-kind@v0.5.0
+  acc_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform_version: 
+        - "0.12.29"
+        - "0.13.5"
+        - "0.14.1"
+    steps:
+    - uses: actions/checkout@master
+    - uses: engineerd/setup-kind@v0.5.0  
     - name: Acceptance Tests
+      env: 
+        TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
       run: |
-        make testacc KUBE_CONFIG_PATH="${HOME}/.kube/config"
+        KUBE_CONFIG_PATH="${HOME}/.kube/config" make testacc 


### PR DESCRIPTION
### Description

This PR adds a matrix build to run the acceptance tests against 0.12, 0.13, and 0.14. We could probably script further to pull the latest versions from the CDN or git tags but for now its hard coded.
