### PR TITLE
Move kubernetes config check out of providerConfigure

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -268,15 +268,11 @@ func checkKubernetesConfigurationValid(d *schema.ResourceData) error {
 	return fmt.Errorf(`provider not configured: you must configure a path to your kubeconfig
 or explicitly supply credentials via the provider block or environment variables.
 
-See our documentation at: %s`, authDocumentationURL)
+See our authentication documentation at: %s`, authDocumentationURL)
 }
 
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, diag.Diagnostics) {
 	m := &Meta{data: d}
-
-	if err := checkKubernetesConfigurationValid(d); err != nil {
-		return nil, diag.FromErr(err)
-	}
 
 	settings := cli.New()
 	settings.Debug = d.Get("debug").(bool)
@@ -359,6 +355,10 @@ func (m *Meta) GetHelmConfiguration(namespace string) (*action.Configuration, er
 	defer m.Unlock()
 	debug("[INFO] GetHelmConfiguration start")
 	actionConfig := new(action.Configuration)
+
+	if err := checkKubernetesConfigurationValid(m.data); err != nil {
+		return nil, err
+	}
 
 	kc, err := newKubeConfig(m.data, &namespace)
 	if err != nil {


### PR DESCRIPTION
### Description

This PR moves the logic to check that the kubernetes config for the provider is not empty from `providerConfigure()` to `GetHelmConfiguration()` which gets called later. Doing this early was triggering the progressive apply issue.

Fixes #647

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

See GitHub Actions output.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix error when using outputs from another resource in the provider block
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
