### PR TITLE
hotfix new stable chart URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.6 (Unreleased)
+
+HOTFIX:
+* Update URL for stable chart repo 
+
 ## 0.10.5 (June 11, 2020)
 
 FIXES:

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -449,7 +449,7 @@ func (m *Meta) initHelmHomeIfNeeded(d *schema.ResourceData) error {
 		return nil
 	}
 
-	stableRepositoryURL := "https://kubernetes-charts.storage.googleapis.com"
+	stableRepositoryURL := "https://charts.helm.sh/stable"
 	localRepositoryURL := "http://127.0.0.1:8879/charts"
 
 	if err := installer.Initialize(m.Settings.Home, os.Stdout, false, *m.Settings, stableRepositoryURL, localRepositoryURL); err != nil {


### PR DESCRIPTION
### Description

This PR is a hotfix to 0.10.x to update the URL for the the stable chart repository.

Fixes #649
