### PR TITLE
Option for provider specific proxy

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -250,7 +250,7 @@ func kubernetesResource() *schema.Resource {
 				},
 				Description: "",
 			},
-			"bastion_host": {
+			"proxy_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "URL to the proxy to be used for all requests",

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -250,6 +250,11 @@ func kubernetesResource() *schema.Resource {
 				},
 				Description: "",
 			},
+			"bastion_host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "URL to the proxy to be used for all requests",
+			},
 		},
 	}
 }

--- a/helm/structure_kubeconfig.go
+++ b/helm/structure_kubeconfig.go
@@ -176,7 +176,7 @@ func newKubeConfig(configData *schema.ResourceData, namespace *string) (*KubeCon
 		overrides.AuthInfo.Exec = exec
 	}
 
-	if v, ok := k8sGetOk(configData, "bastion_host"); ok {
+	if v, ok := k8sGetOk(configData, "proxy_url"); ok {
 		overrides.ClusterDefaults.ProxyURL = v.(string)
 	}
 

--- a/helm/structure_kubeconfig.go
+++ b/helm/structure_kubeconfig.go
@@ -176,6 +176,10 @@ func newKubeConfig(configData *schema.ResourceData, namespace *string) (*KubeCon
 		overrides.AuthInfo.Exec = exec
 	}
 
+	if v, ok := k8sGetOk(configData, "bastion_host"); ok {
+		overrides.ClusterDefaults.ProxyURL = v.(string)
+	}
+
 	overrides.Context.Namespace = "default"
 
 	if namespace != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -152,9 +152,4 @@ The `kubernetes` block supports:
   * `command` - (Required) Command to execute.
   * `args` - (Optional) List of arguments to pass when executing the plugin.
   * `env` - (Optional) Map of environment variables to set when executing the plugin.
-
-## Experiments
-
-The provider takes an `experiments` block that allows you enable experimental features by setting them to `true`.
-
-* `manifest` - Enable storing of the rendered manifest for `helm_release` so the full diff of what is changing can been seen in the plan.
+* `proxy_url` - (Optional) URL of the proxy to use for calls.


### PR DESCRIPTION
### Description
Adds `proxy_url` option to provider settings which allows to use providers specific proxy.

[Example](https://github.com/jenkins-x/terraform-google-jx/pull/170/commits/647decad45fb192d70295bdcc5bd3289938f0aae#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR66) usage, note how this can be combined with external provider for form dependency on bastion host

Use case:
Setting up private GKE and provisioning kubernetes resources after cluster is initialized

Alternative (current) solutions:
- use `HTTPS_PROXY` which is then used by all providers and if bastion host is created by google provider it cannot be used to bootstrap the project and would require two runs (once without HTTPS proxy which will fail kubernetes resources but will create bastion, second with bastion as HTTP_PROXY)
- separate  terraform to multiple independent stages, first provision GKE infrastructure and subsequently run kubernetes specific resources. Downside is that this requires manual step and complicated usage of provided modules. E.g using this approach with https://github.com/jenkins-x/terraform-google-jx would force users to manually apply multi stage approach even when not using private cluster 

Implementation:
Expose setting of proxy which is currently only set through env variables. As of `k8s.io` v0.19 proxy setting is exposed in cluster connection setting. This required updating dependencies which are first split to change in `go.mod` and second commit for `go vendor` last commit contains changes itself

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
HTTPS_PROXY=localhost:8888 KUBE_CONFIG_PATH=~/.kube/config make testacc TESTARGS='-run=TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run=TestAcc -timeout 10m
2021/01/10 18:46:16 Building chart repository...
2021/01/10 18:46:16 Created repository package for "broken-chart"
2021/01/10 18:46:16 Created repository package for "dependency-bar"
2021/01/10 18:46:16 Created repository package for "dependency-foo"
2021/01/10 18:46:16 Created repository package for "test-chart"
2021/01/10 18:46:16 Created repository package for "test-chart-v2"
2021/01/10 18:46:16 Created repository package for "umbrella-chart"
2021/01/10 18:46:16 Built chart repository index
2021/01/10 18:46:16 Test repository is listening on http://localhost:56839
=== RUN   TestAccResourceRelease_basic
=== PAUSE TestAccResourceRelease_basic
=== RUN   TestAccResourceRelease_import
=== PAUSE TestAccResourceRelease_import
=== RUN   TestAccResourceRelease_multiple_releases
=== PAUSE TestAccResourceRelease_multiple_releases
=== RUN   TestAccResourceRelease_concurrent
=== PAUSE TestAccResourceRelease_concurrent
=== RUN   TestAccResourceRelease_update
=== PAUSE TestAccResourceRelease_update
=== RUN   TestAccResourceRelease_emptyValuesList
=== PAUSE TestAccResourceRelease_emptyValuesList
=== RUN   TestAccResourceRelease_updateValues
=== PAUSE TestAccResourceRelease_updateValues
=== RUN   TestAccResourceRelease_cloakValues
=== PAUSE TestAccResourceRelease_cloakValues
=== RUN   TestAccResourceRelease_updateMultipleValues
=== PAUSE TestAccResourceRelease_updateMultipleValues
=== RUN   TestAccResourceRelease_repository_url
=== PAUSE TestAccResourceRelease_repository_url
=== RUN   TestAccResourceRelease_updateAfterFail
=== PAUSE TestAccResourceRelease_updateAfterFail
=== RUN   TestAccResourceRelease_updateExistingFailed
=== PAUSE TestAccResourceRelease_updateExistingFailed
=== RUN   TestAccResourceRelease_postrender
=== PAUSE TestAccResourceRelease_postrender
=== RUN   TestAccResourceRelease_namespaceDoesNotExist
=== PAUSE TestAccResourceRelease_namespaceDoesNotExist
=== RUN   TestAccResourceRelease_invalidName
=== PAUSE TestAccResourceRelease_invalidName
=== RUN   TestAccResourceRelease_createNamespace
=== PAUSE TestAccResourceRelease_createNamespace
=== RUN   TestAccResourceRelease_LintFailValues
=== PAUSE TestAccResourceRelease_LintFailValues
=== RUN   TestAccResourceRelease_LintFailChart
=== PAUSE TestAccResourceRelease_LintFailChart
=== RUN   TestAccResourceRelease_dependency
=== PAUSE TestAccResourceRelease_dependency
=== RUN   TestAccResourceRelease_chartURL
=== PAUSE TestAccResourceRelease_chartURL
=== RUN   TestAccResourceRelease_helm_repo_add
    resource_release_test.go:1028: "hashicorp-test" has been added to your repositories

=== PAUSE TestAccResourceRelease_helm_repo_add
=== CONT  TestAccResourceRelease_basic
=== CONT  TestAccResourceRelease_updateExistingFailed
=== CONT  TestAccResourceRelease_updateValues
=== CONT  TestAccResourceRelease_LintFailChart
=== CONT  TestAccResourceRelease_LintFailValues
=== CONT  TestAccResourceRelease_createNamespace
=== CONT  TestAccResourceRelease_invalidName
=== CONT  TestAccResourceRelease_namespaceDoesNotExist
--- PASS: TestAccResourceRelease_LintFailChart (1.22s)
=== CONT  TestAccResourceRelease_postrender
--- PASS: TestAccResourceRelease_LintFailValues (1.32s)
=== CONT  TestAccResourceRelease_helm_repo_add
--- PASS: TestAccResourceRelease_invalidName (4.26s)
=== CONT  TestAccResourceRelease_chartURL
2021/01/10 18:46:34 [DEBUG] [resourceDiff: basic-mzdgyy1fcm] Got chart
2021/01/10 18:46:34 [DEBUG] [resourceDiff: basic-mzdgyy1fcm] Release validated
--- PASS: TestAccResourceRelease_postrender (15.39s)
=== CONT  TestAccResourceRelease_dependency
=== CONT  TestAccResourceRelease_concurrent
--- PASS: TestAccResourceRelease_chartURL (12.50s)
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "hashicorp-test" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 2 charts
Deleting outdated charts
--- PASS: TestAccResourceRelease_helm_repo_add (18.45s)
=== CONT  TestAccResourceRelease_emptyValuesList
--- PASS: TestAccResourceRelease_createNamespace (19.55s)
=== CONT  TestAccResourceRelease_update
--- PASS: TestAccResourceRelease_namespaceDoesNotExist (20.59s)
=== CONT  TestAccResourceRelease_repository_url
--- PASS: TestAccResourceRelease_basic (22.75s)
=== CONT  TestAccResourceRelease_updateMultipleValues
--- PASS: TestAccResourceRelease_updateValues (28.61s)
=== CONT  TestAccResourceRelease_updateAfterFail
2021/01/10 18:46:49 [DEBUG] Starting delete for "concurrent-2-2oz3onesgj-test-chart" Deployment
--- PASS: TestAccResourceRelease_emptyValuesList (11.91s)
=== CONT  TestAccResourceRelease_cloakValues
2021/01/10 18:46:51 [DEBUG] [resourceDiff: update-uuuplgb8wp] Got chart
2021/01/10 18:46:51 [DEBUG] [resourceDiff: update-uuuplgb8wp] Release validated
--- PASS: TestAccResourceRelease_dependency (18.23s)
=== CONT  TestAccResourceRelease_multiple_releases
2021/01/10 18:46:54 [DEBUG] [resourceDiff: test-7] Got chart
2021/01/10 18:46:54 [DEBUG] [resourceDiff: test-7] Release validated
2021/01/10 18:46:54 [DEBUG] [resourceReleaseCreate: test-0] Preparing for installation
2021/01/10 18:46:54 [DEBUG] [INFO] GetHelmConfiguration start
2021/01/10 18:46:54 [DEBUG] Using kubeconfig: /Users/hrvolap/.kube/config
2021/01/10 18:46:54 ---[ values.yaml ]-----------------------------------
9nuxglh9x7: 3o784skav9

2021/01/10 18:46:54 [DEBUG] [resourceReleaseCreate: test-0] Installing chart
--- PASS: TestAccResourceRelease_updateExistingFailed (36.93s)
=== CONT  TestAccResourceRelease_import
--- PASS: TestAccResourceRelease_concurrent (28.14s)
--- PASS: TestAccResourceRelease_repository_url (26.89s)
--- PASS: TestAccResourceRelease_updateMultipleValues (27.09s)
--- PASS: TestAccResourceRelease_update (31.06s)
--- PASS: TestAccResourceRelease_updateAfterFail (23.02s)
--- PASS: TestAccResourceRelease_cloakValues (21.60s)
--- PASS: TestAccResourceRelease_import (22.77s)
--- PASS: TestAccResourceRelease_multiple_releases (33.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-helm/helm	72.067s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add option `proxy_url` for provider specific proxy. Supports http(s), socks5 proxy schemes
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Example usage https://github.com/jenkins-x/terraform-google-jx/pull/170/commits/647decad45fb192d70295bdcc5bd3289938f0aae#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR66

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request

<!--- Thank you for keeping this note for the community --->
