### PR TITLE
Remove test output section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,20 +4,7 @@
 
 ### Acceptance tests
 - [ ] Have you added an acceptance test for the functionality being added?
-- [ ] Have you run the acceptance tests on this branch?
 
-Output from acceptance testing:
-
-<!--
-Replace TestAccXXX with a pattern that matches the tests affected by this PR.
-
-For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
--->
-```
-$ make testacc TESTARGS='-run=TestAccXXX'
-
-...
-```
 
 ### Release Note
 Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):


### PR DESCRIPTION
### Description

Removing this superfluous section because the acc tests always run in the GitHub action on the PR and the test output can be retrieved from the checks tab.