### PR TITLE
Fix documentation for KUBE_TOKEN env var name

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -139,7 +139,7 @@ The `kubernetes` block supports:
 * `host` - (Optional) The hostname (in form of URI) of Kubernetes master. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_USER`.
 * `password` - (Optional) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_PASSWORD`.
-* `token` - (Optional) The bearer token to use for authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_BEARER_TOKEN`.
+* `token` - (Optional) The bearer token to use for authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_TOKEN`.
 * `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. Can be sourced from `KUBE_INSECURE`.
 * `client_certificate` - (Optional) PEM-encoded client certificate for TLS authentication. Can be sourced from `KUBE_CLIENT_CERT_DATA`.
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.


### PR DESCRIPTION
### Description
<!--- Please leave a helpful description of the pull request here. --->
The [documentation](https://registry.terraform.io/providers/hashicorp/helm/latest/docs#token) states that the `kubernetes.token` provider argument can also be supplied via an environment variable called `KUBE_BEARER_TOKEN`, but that is wrong. The referenced variable is `KUBE_TOKEN`. 
The currently documented variable has no effect, causing whoever tries to use it to run into authentication errors like below due to the missing token:

```
Error: Kubernetes cluster unreachable: the server has asked for the client to provide credentials
```

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
No tests, as this is a simple documentation fix referencing an exact piece of code.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Documentation fixes.
```
### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
https://github.com/hashicorp/terraform-provider-helm/blob/master/helm/provider.go#L189-L194

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
