### PR TITLE
Remove kubeconfig file check

### DIFF
--- a/helm/structure_kubeconfig.go
+++ b/helm/structure_kubeconfig.go
@@ -91,9 +91,6 @@ func newKubeConfig(configData *schema.ResourceData, namespace *string) (*KubeCon
 			if err != nil {
 				return nil, err
 			}
-			if _, err := os.Stat(path); err != nil {
-				return nil, fmt.Errorf("could not open kubeconfig %q: %v", p, err)
-			}
 
 			log.Printf("[DEBUG] Using kubeconfig: %s", path)
 			expandedPaths = append(expandedPaths, path)


### PR DESCRIPTION
The kubeconfig file check seems to cause problems when using local_file to create the kubeconfig in the same apply.

Solves https://github.com/hashicorp/terraform-provider-kubernetes/issues/1142

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
