### PR TITLE
Install Terraform version according to matrix in GH actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,9 +25,12 @@ jobs:
         terraform_version: 
         - "0.12.30"
         - "0.13.6"
-        - "0.14.7"
-        - "0.15.0-beta2"
+        - "0.14.10"
+        - "0.15.0"
     steps:
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ matrix.terraform_version }}
     - uses: actions/checkout@main
     - uses: engineerd/setup-kind@v0.5.0  
     - name: Acceptance Tests


### PR DESCRIPTION
### Description

This change introduces an additional step to install the exact Terraform version selected from the matrix  in the GitHub workflow for acceptance tests.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
