### PR TITLE
Fix redacting sensitive values that uses backslashes #737

### DIFF
--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -750,14 +750,14 @@ func TestCloakSetValues(t *testing.T) {
 func TestCloakSetValuesNested(t *testing.T) {
 	d := resourceRelease().Data(nil)
 	err := d.Set("set_sensitive", []interface{}{
-		map[string]interface{}{"name": "foo.qux.bar", "value": "42"},
+		map[string]interface{}{"name": "foo.qux.bar\\.nested", "value": "42"},
 	})
 	if err != nil {
 		t.Fatalf("error setting values: %v", err)
 	}
 
 	qux := map[string]interface{}{
-		"bar": "bar",
+		"bar.nested": "bar",
 	}
 
 	values := map[string]interface{}{
@@ -767,8 +767,8 @@ func TestCloakSetValuesNested(t *testing.T) {
 	}
 
 	cloakSetValues(values, d)
-	if qux["bar"] != sensitiveContentValue {
-		t.Fatalf("error cloak values, expected %q, got %s", sensitiveContentValue, qux["bar"])
+	if qux["bar.nested"] != sensitiveContentValue {
+		t.Fatalf("error cloak values, expected %q, got %s", sensitiveContentValue, qux["bar.nested"])
 	}
 }
 


### PR DESCRIPTION
### Description

Our team has found a security issue on this provider when using field names with backslashes. 
Essentially, set_sentitive doesn't work if we use backslashes because the code was splitting any dot character.

The solution was to ignore splitting when a backslash is added, and remove "\\" when trying to find the set values.

Go doesn't have a look behind feature in regex. Thus, I opted to write a string tokenizer to ignore "." that are prefixed with "\".

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix issue #737 when redacting values that uses backslash characters in field name.
```

### References
#737 


### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
