### PR TITLE
Add support for stand-alone debug mode (launch with -debug argument)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -9,6 +10,7 @@ import (
 )
 
 func main() {
+	debugFlag := flag.Bool("debug", false, "Start provider in stand-alone debug mode.")
 	flag.Parse()
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -16,7 +18,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	plugin.Serve(&plugin.ServeOpts{
+	serveOpts := &plugin.ServeOpts{
 		ProviderFunc: helm.Provider,
-	})
+	}
+	if debugFlag != nil && *debugFlag {
+		plugin.Debug(context.Background(), "registry.terraform.io/hashicorp/helm", serveOpts)
+	} else {
+		plugin.Serve(serveOpts)
+	}
 }


### PR DESCRIPTION
### Description

With this change, developers will be able to launch the provider binary in stand-alone mode and configure Terraform to attach to the running debugger. In this mode, the provider process can then be inspected with any Go debugger, such as Delve.

To launch the provider in debug mode, simply launch the provider binary on the command line and pass `-debug` as an argument. It will print out the connection details for Terraform, which look like this:
```
Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:

        TF_REATTACH_PROVIDERS='{"registry.terraform.io/hashicorp/helm":{"Protocol":"grpc","Pid":34271,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/t7/z1g1xbgn4qzd6pck7d_s1zxh0000gn/T/plugin220728474"}}}'
```

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
