### PR TITLE
[doc] update stable helm charts url

### DIFF
--- a/website/docs/d/template.html.markdown
+++ b/website/docs/d/template.html.markdown
@@ -26,7 +26,7 @@ The following example renders all templates of the `mariadb` chart of the offici
 data "helm_template" "mariadb_instance" {
   name       = "mariadb-instance"
   namespace  = "default"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://charts.helm.sh/stable"
 
   chart   = "mariadb"
   version = "7.1.0"
@@ -70,7 +70,7 @@ The following example renders only the templates `master-statefulset.yaml` and `
 data "helm_template" "mariadb_instance" {
   name       = "mariadb-instance"
   namespace  = "default"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://charts.helm.sh/stable"
 
   chart   = "mariadb"
   version = "7.1.0"


### PR DESCRIPTION
### Description

Official Helm chart url has changed since 13.11.2020. See https://helm.sh/blog/new-location-stable-incubator-charts/
The old chart urls don't work.
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Introduced in #483

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
