### PR TITLE
Remove all or none of object keys in set

### DIFF
--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
@@ -1335,12 +1335,21 @@ func (m schemaMap) diffSet(
 			switch t := schema.Elem.(type) {
 			case *Resource:
 				// This is a complex resource
+				var subKs []string
+				newRemoved := true
 				for k2, schema := range t.Schema {
 					subK := fmt.Sprintf("%s.%s.%s", k, code, k2)
 					err := m.diff(subK, schema, diff, d, true)
 					if err != nil {
 						return err
 					}
+					subKs = append(subKs, subK)
+					if !diff.Attributes[subK].NewRemoved {
+						newRemoved = false
+					}
+				}
+				for _, subK := range subKs {
+					diff.Attributes[subK].NewRemoved = newRemoved
 				}
 			case *Schema:
 				// Copy the schema so that we can set Computed/ForceNew from


### PR DESCRIPTION
### Description
These changes are meant to fix #817 issue. It is meant that all 'set' attributes are always present. If e.g. 'type' attribute is not defined in configuration, it however is stored in state as "". Whereas diff functions consider such an attribute as removed since it is changed from "" in state to nil in configuration. This behavior causes issues described in #817.
The idea is to consider an element is 'set' as removed only if all its attributes are marked as removed.

I'm not a go/tf developer, so my reasoning may be complete nonsense. At least it fixes #817.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
#817

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
