### PR TITLE
Add `proxy_url` configuration to kubernetes block

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -225,6 +225,12 @@ func kubernetesResource() *schema.Resource {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_TOKEN", ""),
 				Description: "Token to authenticate an service account",
 			},
+			"proxy_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "URL to the proxy to be used for all API requests",
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_PROXY_URL", ""),
+			},
 			"exec": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/helm/structure_kubeconfig.go
+++ b/helm/structure_kubeconfig.go
@@ -160,6 +160,10 @@ func newKubeConfig(configData *schema.ResourceData, namespace *string) (*KubeCon
 		overrides.AuthInfo.Token = v.(string)
 	}
 
+	if v, ok := k8sGetOk(configData, "proxy_url"); ok {
+		overrides.ClusterDefaults.ProxyURL = v.(string)
+	}
+
 	if v, ok := k8sGetOk(configData, "exec"); ok {
 		exec := &clientcmdapi.ExecConfig{}
 		if spec, ok := v.([]interface{})[0].(map[string]interface{}); ok {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -151,6 +151,7 @@ The `kubernetes` block supports:
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
+* `proxy_url` - (Optional) URL to the proxy to be used for all API requests. URLs with "http", "https", and "socks5" schemes are supported. Can be sourced from `KUBE_PROXY_URL`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
   * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
   * `command` - (Required) Command to execute.


### PR DESCRIPTION
### Description

Adds support for `proxy_url` in the `kubernetes` block of the provider. This functions identically to the [same parameter in the kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#proxy_url).

Fixes #833

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?

I haven't added acceptance tests, but happy to add some. Wasn't sure exactly how though. Open to guidance on that. I _have_
created a release on my fork here: https://registry.terraform.io/providers/nsmith5/helm/2.4.3 and verified that this works as expected manually.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
* Add support for `proxy_url` in `kubernetes` block for socks and http(s) proxy access to kubernetes cluster.
```
### References

- [Equivalent PR for `proxy_url` support in Kubernetes provider](https://github.com/hashicorp/terraform-provider-kubernetes/pull/1441)
- Very similar PR #654. I open this PR simply to make the implementation identical to the Kubernetes provider behaviour (including environment variable support and documentation matching).

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
