### PR TITLE
feat(repo): add pass_credentials option

### DIFF
--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -70,6 +70,11 @@ func dataTemplate() *schema.Resource {
 				Sensitive:   true,
 				Description: "Password for HTTP basic authentication",
 			},
+			"pass_credentials": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Pass credentials to all domains",
+			},
 			"chart": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -52,6 +52,7 @@ var defaultAttributes = map[string]interface{}{
 	"replace":                    false,
 	"create_namespace":           false,
 	"lint":                       false,
+	"pass_credentials":           false,
 }
 
 func resourceRelease() *schema.Resource {
@@ -101,6 +102,12 @@ func resourceRelease() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 				Description: "Password for HTTP basic authentication",
+			},
+			"pass_credentials": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Pass credentials to all domains",
+				Default:     defaultAttributes["pass_credentials"],
 			},
 			"chart": {
 				Type:        schema.TypeString,
@@ -1170,7 +1177,7 @@ func chartPathOptions(d resourceGetter, m *Meta, cpo *action.ChartPathOptions) (
 	cpo.Version = version
 	cpo.Username = d.Get("repository_username").(string)
 	cpo.Password = d.Get("repository_password").(string)
-
+	cpo.PassCredentialsAll = d.Get("pass_credentials").(bool)
 	return cpo, chartName, nil
 }
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

This PR adds supports for the `--pass-credentials` option of the Helm client. This is useful when charts are located in a different location than where the index.yaml is. Some registries also rewrite the chart to include the port in the URL section. This prevented Helm from being able to download the Chart.

### Acceptance tests

I did not see any tests on attributes like `repository_username` so I did not try to add some as this is the same type of attribute

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added `pass_credentials` attributes to the `helm_release` resource. Defaults to `false`
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
#847 
https://helm.sh/docs/helm/helm_install/#options See `--pass-credentials` options.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
