### PR TITLE
Fix OCI registry login concurrency issue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,3 +53,5 @@ jobs:
         TESTARGS: "-parallel 1"
       run: |
         KUBE_CONFIG_PATH="${KUBECONFIG}" make testacc 
+
+

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1264,7 +1264,7 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 
 	if usepassword {
 		// log into OCI registry
-		t.Log("pushing test-chart to OCI registry")
+		t.Log("logging in to test-chart to OCI registry")
 		cmd = exec.Command("helm", "registry", "login",
 			fmt.Sprintf("localhost:%d", ociRegistryPort),
 			"--username", "hashicorp",
@@ -1366,7 +1366,7 @@ func TestAccResourceRelease_OCI_login(t *testing.T) {
 		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHelmReleaseConfig_OCI_login_multiple(testResourceName, namespace, name, ociRegistryURL, "1.2.3"),
+				Config: testAccHelmReleaseConfig_OCI_login_multiple(testResourceName, namespace, name, ociRegistryURL, "1.2.3", "hashicorp", "terraform"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test1", "metadata.0.name", name+"1"),
 					resource.TestCheckResourceAttr("helm_release.test1", "metadata.0.namespace", namespace),
@@ -1394,7 +1394,7 @@ func testAccHelmReleaseConfig_OCI(resource, ns, name, repo, version string) stri
 	`, resource, name, ns, repo, version)
 }
 
-func testAccHelmReleaseConfig_OCI_login_multiple(resource, ns, name, repo, version string) string {
+func testAccHelmReleaseConfig_OCI_login_multiple(resource, ns, name, repo, version, username, password string) string {
 	return fmt.Sprintf(`
 		resource "helm_release" "%s1" {
  			name        = "%s1"
@@ -1402,6 +1402,9 @@ func testAccHelmReleaseConfig_OCI_login_multiple(resource, ns, name, repo, versi
 			repository  = %q
 			version     = %q
 			chart       = "test-chart"
+
+			repository_username = %q
+			repository_password = %q
 		}
 		resource "helm_release" "%[1]s2" {
 			name       = "%[2]s2"
@@ -1409,8 +1412,11 @@ func testAccHelmReleaseConfig_OCI_login_multiple(resource, ns, name, repo, versi
 		   repository  = %[4]q
 		   version     = %[5]q
 		   chart       = "test-chart"
+
+		   repository_username = %[6]q
+		   repository_password = %[7]q
 	   }
-	`, resource, name, ns, repo, version)
+	`, resource, name, ns, repo, version, username, password)
 }
 
 func testAccHelmReleaseConfig_OCI_chartName(resource, ns, name, chartName, version string) string {

--- a/helm/testdata/oci_registry/auth.htpasswd
+++ b/helm/testdata/oci_registry/auth.htpasswd
@@ -1,0 +1,1 @@
+hashicorp:$2y$05$w2qcus7DpEEmnm7u4qeX5upuioXmnWRa8ICgXQZznN6xhxbsqBHK6


### PR DESCRIPTION
The provider should log into each registry only once. I've added a mutex here so that parallel login attempts don't interfere with each other.

I've also added a test case which spins up a passworded OCI registry and uses it to create multiple releases. 

Fixes #845 

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix OCI registry concurrent login issue 
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
