### PR TITLE
Do dependency update in resourceDiff #771

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -737,11 +737,23 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 	}
 
 	// Get Chart metadata, if we fail - we're done
-	chart, _, err := getChart(d, meta.(*Meta), chartName, cpo)
+	chart, path, err := getChart(d, meta.(*Meta), chartName, cpo)
 	if err != nil {
 		return nil
 	}
 	debug("%s Got chart", logID)
+
+	// check and update the chart's dependencies if needed
+	updated, err := checkChartDependencies(d, chart, path, m)
+	if err != nil {
+		return err
+	} else if updated {
+		// load the chart again if its dependencies have been updated
+		chart, err = loader.Load(path)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Validates the resource configuration, the values, the chart itself, and
 	// the combination of both.

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1072,6 +1072,19 @@ func TestAccResourceRelease_dependency(t *testing.T) {
 					resource.TestCheckResourceAttr("helm_release.test", "dependency_update", "true"),
 				),
 			},
+			{
+				PreConfig: func() {
+					if err := removeSubcharts("umbrella-chart"); err != nil {
+						t.Fatalf("Failed to remove subcharts: %s", err)
+					}
+				},
+				Config: testAccHelmReleaseConfigDependencyUpdateWithLint(testResourceName, namespace, name, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "3"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+					resource.TestCheckResourceAttr("helm_release.test", "dependency_update", "true"),
+				),
+			},
 		},
 	})
 }
@@ -1462,6 +1475,24 @@ func testAccHelmReleaseConfigManifestExperimentEnabled(resource, ns, name, versi
 			chart       = "test-chart"
 		}
 	`, resource, name, ns, testRepositoryURL, version)
+}
+
+func testAccHelmReleaseConfigDependencyUpdateWithLint(resource, ns, name string, dependencyUpdate bool) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+ 			name        = %q
+			namespace   = %q
+  			chart       = "./testdata/charts/umbrella-chart"
+
+			dependency_update = %t
+			lint = true
+
+			set {
+				name = "fake"
+				value = "fake"
+			}
+		}
+	`, resource, name, ns, dependencyUpdate)
 }
 
 func testAccHelmReleaseConfig_helm_repo_add(resource, ns, name string) string {

--- a/helm/testdata/charts/umbrella-chart/templates/service.yaml
+++ b/helm/testdata/charts/umbrella-chart/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "umbrella-chart.fullname" . }}
   labels:
     {{- include "umbrella-chart.labels" . | nindent 4 }}
+    {{- /* The dependency-bar label template is included here to
+    test dependency updating. */}}
+    {{- include "dependency-bar.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
### Description

Adding the dependency update function earlier in the provider flow. Currently attempting to use a template from a subchart in a template in the parent chart fails if linting or if the experimental manifest feature  is enabled. Both the acceptance test and some local testing with the provider changes fix these issues. Running the new test without the dependency update change in `resource_release.go` fails as expected. 

Fixes #771 
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
The resourceDiff function now respects the dependency_update setting which fixes a bug in charts with dependencies that use linting or the experimental manifests feature.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

#771 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
