### PR TITLE
Add example for helm chart from OCI registry

### DIFF
--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -81,6 +81,28 @@ resource "helm_release" "example" {
 }
 ```
 
+## Example Usage - Chart published in OCI registry
+
+This provider supports helm charts published in OCI registry.
+
+```hcl
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+resource "helm_release" "simple-page" {
+  chart               = "simple-page"
+  version             = "0.1.0"
+  name                = "simple-page"
+  repository          = "oci://${data.aws_caller_identity.current.account_id}.dkr.ecr.us-west-1.amazonaws.com"
+  repository_username = data.aws_ecr_authorization_token.token.user_name
+  repository_password = data.aws_ecr_authorization_token.token.password
+
+  lifecycle {
+    ignore_changes = [repository_password]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
### Description

Add example of helm chart stored in OCI registry as there no mentioning that helm provider has support of this source.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

Issue #859 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
