### PR TITLE
Add OCI registry block to provider

### DIFF
--- a/.changelog/862.txt
+++ b/.changelog/862.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add support for configuring OCI registries inside provider block
+```

--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -392,7 +392,7 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = OCIRegistryLogin(actionConfig, d)
+	err = OCIRegistryLogin(actionConfig, d, m)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -489,7 +489,7 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = OCIRegistryLogin(actionConfig, d)
+	err = OCIRegistryLogin(actionConfig, d, m)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -622,7 +622,7 @@ func resourceReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		d.Partial(true)
 		return diag.FromErr(err)
 	}
-	err = OCIRegistryLogin(actionConfig, d)
+	err = OCIRegistryLogin(actionConfig, d, m)
 	if err != nil {
 		d.Partial(true)
 		return diag.FromErr(err)
@@ -759,7 +759,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 	if err != nil {
 		return err
 	}
-	err = OCIRegistryLogin(actionConfig, d)
+	err = OCIRegistryLogin(actionConfig, d, m)
 	if err != nil {
 		return err
 	}

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1509,7 +1509,7 @@ func TestAccResourceRelease_OCI_registry_login(t *testing.T) {
 		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHelmReleaseConfig_OCI_login_provider(testResourceName, namespace, name, ociRegistryURL, "1.2.3", "hashicorp", "terraform"),
+				Config: testAccHelmReleaseConfig_OCI_login_provider(os.Getenv("KUBE_CONFIG_PATH"), testResourceName, namespace, name, ociRegistryURL, "1.2.3", "hashicorp", "terraform"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.name", name),
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", namespace),
@@ -1521,11 +1521,11 @@ func TestAccResourceRelease_OCI_registry_login(t *testing.T) {
 	})
 }
 
-func testAccHelmReleaseConfig_OCI_login_provider(resource, ns, name, repo, version, username, password string) string {
+func testAccHelmReleaseConfig_OCI_login_provider(kubeconfig, resource, ns, name, repo, version, username, password string) string {
 	return fmt.Sprintf(`
 		provider "helm" {
 			kubernetes {
-				config_path = "~/.kube/config"
+				config_path = %q
 			}
 			registry {
 		  		url      = %q
@@ -1537,9 +1537,9 @@ func testAccHelmReleaseConfig_OCI_login_provider(resource, ns, name, repo, versi
  			name        = "%s"
 			namespace   = %q
 			version     = %q
-			repository  = %[1]q
+			repository  = %[2]q
 			chart       = "test-chart"
-		}`, repo, username, password, resource, name, ns, version)
+		}`, kubeconfig, repo, username, password, resource, name, ns, version)
 }
 
 func TestAccResourceRelease_OCI_login(t *testing.T) {

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1493,6 +1493,55 @@ func TestAccResourceRelease_OCI_repository(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_OCI_registry_login(t *testing.T) {
+	name := randName("oci")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	ociRegistryURL, shutdown := setupOCIRegistry(t, false)
+	defer shutdown()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfig_OCI_login_provider(testResourceName, namespace, name, ociRegistryURL, "1.2.3", "hashicorp", "terraform"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+				),
+			},
+		},
+	})
+}
+
+func testAccHelmReleaseConfig_OCI_login_provider(resource, ns, name, repo, version, username, password string) string {
+	return fmt.Sprintf(`
+		provider "helm" {
+			kubernetes {
+				config_path = "~/.kube/config"
+			}
+			registry {
+		  		url      = %q
+		  		username = %q
+		  		password = %q
+			}
+	  	}
+		resource "helm_release" "%s" {
+ 			name        = "%s"
+			namespace   = %q
+			version     = %q
+			repository  = %[1]q
+			chart       = "test-chart"
+		}`, repo, username, password, resource, name, ns, version)
+}
+
 func TestAccResourceRelease_OCI_login(t *testing.T) {
 	name := randName("oci")
 	namespace := createRandomNamespace(t)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -27,6 +27,20 @@ provider "helm" {
   kubernetes {
     config_path = "~/.kube/config"
   }
+
+  # localhost registry with password protection
+  registry {
+    url = "oci://localhost:5000"
+    username = "username"
+    password = "password"
+  }
+
+  # private registry
+  registry {
+    url = "oci://private.registry"
+    username = "username"
+    password = "password"
+  }
 }
 
 resource "helm_release" "nginx_ingress" {
@@ -137,6 +151,7 @@ The following arguments are supported:
 * `helm_driver` - (Optional) "The backend storage driver. Valid values are: `configmap`, `secret`, `memory`, `sql`. Defaults to `secret`.
   Note: Regarding the sql driver, as of helm v3.2.0 SQL support exists only for the postgres dialect. The connection string can be configured by setting the `HELM_DRIVER_SQL_CONNECTION_STRING` environment variable e.g. `HELM_DRIVER_SQL_CONNECTION_STRING=postgres://username:password@host/dbname` more info [here](https://pkg.go.dev/github.com/lib/pq).
 * `kubernetes` - Kubernetes configuration block.
+* `registry` - Private OCI registry configuration block. Can be specified multiple times.
 
 The `kubernetes` block supports:
 
@@ -157,6 +172,12 @@ The `kubernetes` block supports:
   * `command` - (Required) Command to execute.
   * `args` - (Optional) List of arguments to pass when executing the plugin.
   * `env` - (Optional) Map of environment variables to set when executing the plugin.
+
+The `registry` block has options:
+
+* `url` - (Required) url to the registry in format `oci://host:port`
+* `username` - (Required) username to registry
+* `password` - (Required) password to registry
 
 ## Experiments
 


### PR DESCRIPTION
### Description

Add OCI registry to block to provider definition to have same behavior as Helm binary where you are doing `helm registry login` only once. As registry is specified in every `helm_release` username and password are marked as required variables. In documentation it is also marked as option for private registries only.

This would allow to keep passwords to registries away from helm_release resource and ability to use short live token without affecting chart resource.

For compatibility reasons I've kept ability to specify password for OCI in helm_release resource.

Example code for short live token:

```hcl
data "aws_ecr_authorization_token" "token" {}

resource "aws_ecr_repository" "foo" {
  name = "foo"
}

provider "helm" {
  registry {
    url      = aws_ecr_repository.foo.repository_url
    username = data.aws_ecr_authorization_token.token.user_name
    password = data.aws_ecr_authorization_token.token.password
  }
}
```

### Acceptance tests
- None

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add "registry" block to helm provider
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Related issues: #861

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
