### PR TITLE
Add post renderer args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.6.0
 
 * Upgrade helm to 3.9.0
+* Add args attribute in post-render block
 
 ## 2.5.1 (April 11, 2022)
 

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -537,7 +537,14 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 	client.CreateNamespace = d.Get("create_namespace").(bool)
 
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-		pr, err := postrender.NewExec(cmd)
+		av := d.Get("postrender.0.args").([]interface{})
+		var args []string
+		for _,arg := range av {
+			args = append(args, arg.(string))
+		}
+
+		pr, err := postrender.NewExec(cmd, args...)
+
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -646,7 +653,14 @@ func resourceReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	client.Description = d.Get("description").(string)
 
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-		pr, err := postrender.NewExec(cmd)
+		av := d.Get("postrender.0.args").([]interface{})
+		var args []string
+		for _,arg := range av {
+			args = append(args, arg.(string))
+		}
+
+		pr, err := postrender.NewExec(cmd, args...)
+
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -795,7 +809,14 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		client.Description = d.Get("description").(string)
 
 		if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-			pr, err := postrender.NewExec(cmd)
+			av := d.Get("postrender.0.args").([]interface{})
+			var args []string
+			for _,arg := range av {
+				args = append(args, arg.(string))
+			}
+
+			pr, err := postrender.NewExec(cmd, args...)
+
 			if err != nil {
 				return err
 			}

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -541,12 +541,10 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 	client.Replace = d.Get("replace").(bool)
 	client.Description = d.Get("description").(string)
 	client.CreateNamespace = d.Get("create_namespace").(bool)
-
+	
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
 		av := d.Get("postrender.0.args")
-
 		var args []string
-
 		for _, arg := range av.([]interface{}) {
 			if arg == nil {
 				continue

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -335,6 +335,12 @@ func resourceRelease() *schema.Resource {
 							Required:    true,
 							Description: "The command binary path.",
 						},
+						"args": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "an argument to the post-renderer (can specify multiple)",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -537,14 +543,18 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 	client.CreateNamespace = d.Get("create_namespace").(bool)
 
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-		av := d.Get("postrender.0.args").([]interface{})
+		av := d.Get("postrender.0.args")
+
 		var args []string
-		for _,arg := range av {
+
+		for _, arg := range av.([]interface{}) {
+			if arg == nil {
+				continue
+			}
 			args = append(args, arg.(string))
 		}
 
 		pr, err := postrender.NewExec(cmd, args...)
-
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -653,14 +663,16 @@ func resourceReleaseUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	client.Description = d.Get("description").(string)
 
 	if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-		av := d.Get("postrender.0.args").([]interface{})
+		av := d.Get("postrender.0.args")
 		var args []string
-		for _,arg := range av {
+		for _, arg := range av.([]interface{}) {
+			if arg == nil {
+				continue
+			}
 			args = append(args, arg.(string))
 		}
 
 		pr, err := postrender.NewExec(cmd, args...)
-
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -809,9 +821,12 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		client.Description = d.Get("description").(string)
 
 		if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-			av := d.Get("postrender.0.args").([]interface{})
+			av := d.Get("postrender.0.args")
 			var args []string
-			for _,arg := range av {
+			for _, arg := range av.([]interface{}) {
+				if arg == nil {
+					continue
+				}
 				args = append(args, arg.(string))
 			}
 

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -132,7 +132,7 @@ The `set` and `set_sensitive` blocks support:
 The `postrender` block supports two attributes:
 
 * `binary_path` - (Required) relative or full path to command binary.
-* `args` - (Optional) an argument to the post-renderer (can specify multiple)
+* `args` - (Optional) a list of arguments to supply to the post-renderer.
 
 
 

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -129,7 +129,7 @@ The `set` and `set_sensitive` blocks support:
 * `value` - (Required) value of the variable to be set.
 * `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
 
-The `postrender` block supports a single attribute:
+The `postrender` block supports two attributes:
 
 * `binary_path` - (Required) relative or full path to command binary.
 * `args` - (Optional) an argument to the post-renderer (can specify multiple)

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -132,6 +132,8 @@ The `set` and `set_sensitive` blocks support:
 The `postrender` block supports a single attribute:
 
 * `binary_path` - (Required) relative or full path to command binary.
+* `args` - (Optional) an argument to the post-renderer (can specify multiple)
+
 
 
 ## Attributes Reference


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Added args attribute for post-render as part of new feature implemented in Helm v3.9.0

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add args attribute in post-render block
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
