### PR TITLE
add v1alpha1 diagnostic message / updated docs

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -242,6 +242,18 @@ func kubernetesResource() *schema.Resource {
 						"api_version": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateDiagFunc: func(val interface{}, key cty.Path) (diags diag.Diagnostics) {
+								api_version := val.(string)
+
+								if api_version == "client.authentication.k8s.io/v1alpha1" {
+									return diag.Diagnostics{{
+										Severity: diag.Warning,
+										Summary:  fmt.Sprintf("v1alpha1 is not recommended, use v1beta1"),
+										Detail:   fmt.Sprintf("v1alpha1 authentication API was removed in Kubernetes 1.24, removal of alpha APIs is expected in minor version bumps of Kubernetes"),
+									}}
+								}
+								return
+							},
 						},
 						"command": {
 							Type:     schema.TypeString,

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -249,7 +249,7 @@ func kubernetesResource() *schema.Resource {
 									return diag.Diagnostics{{
 										Severity: diag.Warning,
 										Summary:  fmt.Sprintf("v1alpha1 is not recommended, use v1beta1"),
-										Detail:   fmt.Sprintf("v1alpha1 authentication API was removed in Kubernetes 1.24, removal of alpha APIs is expected in minor version bumps of Kubernetes"),
+										Detail:  "v1alpha1 of the client authentication API is removed in Kubernetes client versions 1.24 and above. You may need to update your exec plugin to use the latest version."),
 									}}
 								}
 								return

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -248,7 +248,7 @@ func kubernetesResource() *schema.Resource {
 								if api_version == "client.authentication.k8s.io/v1alpha1" {
 									return diag.Diagnostics{{
 										Severity: diag.Warning,
-										Summary:  fmt.Sprintf("v1alpha1 is not recommended, use v1beta1"),
+										Summary:  "v1alpha1 of the client authentication API has been removed, use v1beta1 or above",
 										Detail:  "v1alpha1 of the client authentication API is removed in Kubernetes client versions 1.24 and above. You may need to update your exec plugin to use the latest version."),
 									}}
 								}

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -249,7 +249,7 @@ func kubernetesResource() *schema.Resource {
 									return diag.Diagnostics{{
 										Severity: diag.Warning,
 										Summary:  "v1alpha1 of the client authentication API has been removed, use v1beta1 or above",
-										Detail:  "v1alpha1 of the client authentication API is removed in Kubernetes client versions 1.24 and above. You may need to update your exec plugin to use the latest version."),
+										Detail:   "v1alpha1 of the client authentication API is removed in Kubernetes client versions 1.24 and above. You may need to update your exec plugin to use the latest version.",
 									}}
 								}
 								return

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -117,7 +117,7 @@ provider "helm" {
     host                   = var.cluster_endpoint
     cluster_ca_certificate = base64decode(var.cluster_ca_cert)
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
       command     = "aws"
     }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Prevents any future users to get issues when using helm provider by leading them to right version to use.

when running `terraform plan` with api_version set to `v1alpha1` in exec block

```
│ Warning: v1alpha1 is not recommended, use v1beta1
│ 
│   with provider["registry.terraform.io/hashicorp/helm"],
│   on main.tf line 14, in provider "helm":
│   14:       api_version = "client.authentication.k8s.io/v1alpha1"
│ 
│ v1alpha1 authentication API was removed in Kubernetes 1.24, removal of alpha APIs is expected in minor version bumps of Kubernetes
│ 
│ (and one more similar warning elsewhere)
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

#893 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
