### PR TITLE
Tweak sensitive values appearence in diff to not be b64-encoded

### DIFF
--- a/helm/testdata/manifest_json/rendered_manifest.json
+++ b/helm/testdata/manifest_json/rendered_manifest.json
@@ -14,7 +14,7 @@
             }
         },
         "data": {
-            "PASSWORD": "KHNlbnNpdGl2ZSB2YWx1ZSA5NTIwYWUyM2E3MTA4ZmUxKQ=="
+            "PASSWORD": "(sensitive value 9520ae23a7108fe1)"
         }
     },
     "service/v1/diff-tester": {


### PR DESCRIPTION
### Description

When sensitive value within a secret is replaced with string like `(sensitive value 123456789)`, upon converting it to json, it is base64-encoded which creates string like `KHNlbnNpdGl2ZSB2YWx1ZSA5NTIwYWUyM2E3MTA4ZmUxKQ==` in the diff. It's not very intuitive.

Another small issue fixed is when `set_sensitive` is set to an empty string this effectively adds `(sensitive value 123456)` between each character in rendered manifest. This fix ignores empty sensitive values.

### Acceptance tests
- No new tests


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Manifest diff should show sensitive values as non-base64-encoded (sensitive value XXX) string.
* Passing empty value to `set_sensitive` is ignored in manifest diff.
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
