### PR TITLE
Larger diff than expected when updating helm_release 'set' 'value'

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -152,6 +152,7 @@ func resourceRelease() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 							// TODO: use ValidateDiagFunc once an SDK v2 version of StringInSlice exists.
 							// https://github.com/hashicorp/terraform-plugin-sdk/issues/534
 							ValidateFunc: validation.StringInSlice([]string{

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -448,6 +448,7 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 	name := randName("test-update-existing-failed")
 	namespace := createRandomNamespace(t)
 	defer deleteNamespace(t, namespace)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -448,7 +448,6 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 	name := randName("test-update-existing-failed")
 	namespace := createRandomNamespace(t)
 	defer deleteNamespace(t, namespace)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -486,6 +485,61 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceRelease_updateSetValue(t *testing.T) {
+	name := randName("test-update-set-value")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	// Ensure that 'set' 'type' arguments don't disappear when updating a 'set' 'value' argument.
+	// use  checkResourceAttrExists rather than testCheckResourceAttrSet as the latter also checks if the value is not ""
+	// and the default for 'type' is an empty string when not explicitly set.
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfigSet(
+					testResourceName, namespace, name, "1.2.3", "initial",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkResourceAttrExists("helm_release.test", "set.0.type"),
+					checkResourceAttrExists("helm_release.test", "set.1.type"),
+				),
+			},
+			{
+				Config: testAccHelmReleaseConfigSet(
+					testResourceName, namespace, name, "1.2.3", "updated",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkResourceAttrExists("helm_release.test", "set.0.type"),
+					checkResourceAttrExists("helm_release.test", "set.1.type"),
+				),
+			},
+		},
+	})
+}
+
+func checkResourceAttrExists(name, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s in %s", name, ms.Path)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s in %s", name, ms.Path)
+		}
+
+		if _, ok := is.Attributes[key]; ok {
+			return nil
+		}
+		return fmt.Errorf("%s: Attribute '%s' expected to be set", name, key)
+	}
 }
 
 func TestAccResourceRelease_postrender(t *testing.T) {
@@ -674,6 +728,29 @@ func testAccHelmReleaseConfigSensitiveValue(resource, ns, name, chart, version s
 			  }
 		}
 	`, resource, name, ns, testRepositoryURL, chart, version, key, value)
+}
+
+func testAccHelmReleaseConfigSet(resource, ns, name, version, setValue string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+ 			name        = %q
+			namespace   = %q
+			description = "Test"
+			repository  = %q
+  			chart       = "test-chart"
+			version     = %q
+
+			set {
+				name = "foo"
+				value = %q
+			}
+
+			set {
+				name = "fizz"
+				value = 1337
+			}
+		}
+	`, resource, name, ns, testRepositoryURL, version, setValue)
 }
 
 func TestGetValues(t *testing.T) {


### PR DESCRIPTION
### Description

Fix issue #915 where when re-deploying a helm_release after changing a 'set' 'value' the plan generated indicates that values not changing will be deleted and re-applied even though they have not been changed.

The issue is caused by the resource diff process removing the 'set' 'type' value from the state as it was not set in the original terraform code. When initially applying the plan the default value "" was used for the 'set' 'type' and stored in the state, when redeploying the original value of 'set' 'type' is requested  but as no default has been set in the schema it is marked as removed, which then results in null being stored in the state for the value of 'set' 'type'.
This causes an internal warning to be generated in the logs:
"Provider "registry.terraform.io/hashicorp/helm" produced an unexpected new value for helm_release.test during refresh."

### Acceptance tests
- [Y] Have you added an acceptance test for the functionality being added?
  - TestAccResourceRelease_updateSetValue - confirms that 'type' is not lost when updating value.


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix large diffs being generated when updating a 'set' 'value'
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
- #915 
- Possible fix for #711

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
