### PR TITLE
Add kube version parameter to template

### DIFF
--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -301,6 +301,11 @@ func dataTemplate() *schema.Resource {
 				Description: "Kubernetes api versions used for Capabilities.APIVersions",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"kube_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Kubernetes api versions used for KubeVersion",
+			},
 			"include_crds": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -366,6 +371,16 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 		for _, apiVersion := range apiVersionsValues {
 			apiVersions = append(apiVersions, apiVersion.(string))
+		}
+	}
+
+	var err error
+	var kubeVersion *chartutil.KubeVersion
+	kubeVersionStr := d.Get("kube_version").(string)
+	if kubeVersionStr != "" {
+		kubeVersion, err = chartutil.ParseKubeVersion(kubeVersionStr)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -455,6 +470,7 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	client.ClientOnly = !d.Get("validate").(bool)
 	client.APIVersions = chartutil.VersionSet(apiVersions)
 	client.IncludeCRDs = d.Get("include_crds").(bool)
+	client.KubeVersion = kubeVersion
 
 	skipTests := d.Get("skip_tests").(bool)
 


### PR DESCRIPTION
### Description

This adds an option to set kube version when running Helm template. This is important because there are Helm charts which require a minimum Kubernetes version of 1.21 but the default KubeVersion passed to Helm is 1.20.
https://github.com/helm/helm/blob/d84655a9c527e090d2f50ed097beebf3aeed0421/pkg/chartutil/capabilities.go#L31-L50

Adding an option to set a custom KubeVersion is a good work around when there are issues.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add option to configure kube version.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
