### PR TITLE
Support setting repository password from an environment variable

### DIFF
--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -70,6 +70,11 @@ func dataTemplate() *schema.Resource {
 				Sensitive:   true,
 				Description: "Password for HTTP basic authentication",
 			},
+			"repository_password_env": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of an environment variable that holds the password for HTTP basic authentication",
+			},
 			"pass_credentials": {
 				Type:        schema.TypeBool,
 				Optional:    true,

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -430,6 +430,12 @@ func OCIRegistryLogin(actionConfig *action.Configuration, d dataGetter) error {
 
 	username := d.Get("repository_username").(string)
 	password := d.Get("repository_password").(string)
+	passwordEnv := d.Get("repository_password_env").(string)
+
+	if passwordEnv != "" && password == "" {
+		password = os.Getenv(passwordEnv)
+	}
+
 	if username != "" && password != "" {
 		u, err := url.Parse(ociURL)
 		if err != nil {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -103,6 +103,11 @@ func resourceRelease() *schema.Resource {
 				Sensitive:   true,
 				Description: "Password for HTTP basic authentication",
 			},
+			"repository_password_env": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of an environment variable that holds the password for HTTP basic authentication against the reposotory",
+			},
 			"pass_credentials": {
 				Type:        schema.TypeBool,
 				Optional:    true,

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1404,6 +1404,41 @@ func TestAccResourceRelease_OCI_login(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_OCI_login_env(t *testing.T) {
+	name := randName("oci")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	ociRegistryURL, shutdown := setupOCIRegistry(t, true)
+	defer shutdown()
+
+	envVar := "TestAccResourceRelease_OCI_login_env_password"
+	// os.Setenv(envVar, "terraform")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfig_OCI_login_env_multiple(testResourceName, namespace, name, ociRegistryURL, "1.2.3", "hashicorp", envVar),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test1", "metadata.0.name", name+"1"),
+					resource.TestCheckResourceAttr("helm_release.test1", "metadata.0.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test1", "metadata.0.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test1", "status", release.StatusDeployed.String()),
+					resource.TestCheckResourceAttr("helm_release.test2", "metadata.0.name", name+"2"),
+					resource.TestCheckResourceAttr("helm_release.test2", "metadata.0.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test2", "metadata.0.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test2", "status", release.StatusDeployed.String()),
+				),
+			},
+		},
+	})
+}
+
 func testAccHelmReleaseConfig_OCI(resource, ns, name, repo, version string) string {
 	return fmt.Sprintf(`
 		resource "helm_release" "%s" {
@@ -1439,6 +1474,31 @@ func testAccHelmReleaseConfig_OCI_login_multiple(resource, ns, name, repo, versi
 		   repository_password = %[7]q
 	   }
 	`, resource, name, ns, repo, version, username, password)
+}
+
+func testAccHelmReleaseConfig_OCI_login_env_multiple(resource, ns, name, repo, version, username, password_env string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s1" {
+ 			name        = "%s1"
+			namespace   = %q
+			repository  = %q
+			version     = %q
+			chart       = "test-chart"
+
+			repository_username = %q
+			repository_password_env = %q
+		}
+		resource "helm_release" "%[1]s2" {
+			name       = "%[2]s2"
+		   namespace   = %[3]q
+		   repository  = %[4]q
+		   version     = %[5]q
+		   chart       = "test-chart"
+
+		   repository_username = %[6]q
+		   repository_password_env = %[7]q
+	   }
+	`, resource, name, ns, repo, version, username, password_env)
 }
 
 func testAccHelmReleaseConfig_OCI_chartName(resource, ns, name, chartName, version string) string {

--- a/website/docs/d/template.html.markdown
+++ b/website/docs/d/template.html.markdown
@@ -123,6 +123,7 @@ The following arguments are supported:
 * `repository_ca_file` - (Optional) The Repositories CA File.
 * `repository_username` - (Optional) Username for HTTP basic authentication against the repository.
 * `repository_password` - (Optional) Password for HTTP basic authentication against the repository.
+* `repository_password_env` - (Optional) Name of an environment variable that holds the password for HTTP basic authentication against the reposotory.
 * `devel` - (Optional) Use chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored.
 * `version` - (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
 * `namespace` - (Optional) The namespace to install the release into. Defaults to `default`.

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -93,6 +93,7 @@ The following arguments are supported:
 * `repository_ca_file` - (Optional) The Repositories CA File.
 * `repository_username` - (Optional) Username for HTTP basic authentication against the repository.
 * `repository_password` - (Optional) Password for HTTP basic authentication against the repository.
+* `repository_password_env` - (Optional) Name of an environment variable that holds the password for HTTP basic authentication against the reposotory.
 * `devel` - (Optional) Use chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored.
 * `version` - (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
 * `namespace` - (Optional) The namespace to install the release into. Defaults to `default`.


### PR DESCRIPTION
### Description

This tiny PR makes it much easier to use the helm provider with GKE and an OCI repo in Google Artifacts Registry - especially when running in terraform cloud. Instead of adding yet another variable to pass secrets to the helm_release resource, this PR allows simply re-using the environment variable that already exists and is required by the google provider:

```
resource "helm_release" "test" {
  ...

  repository_username = "_json_key"
  repository_password_env = "GOOGLE_CREDENTIALS"
}
```

This has several advantages:

- no need to define another tf variable with the secret and potentially pass it through several layers of modules
- fewer sensitive variables - which reduces the risk of someone forgetting to annotate variables as sensitive
- this is consistent with how most other providers allow passing secrets through environment variables

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Adds the following parameters to the provider
    * repository_password_env - (Optional) Name of an environment variable that holds the password for HTTP basic authentication against the reposotory.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
