### PR TITLE
add nil check of showonly interface value

### DIFF
--- a/.changelog/950.txt
+++ b/.changelog/950.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Crash: Fix `show_only` crash when string is empty
+```

--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -375,7 +375,9 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		showOnlyAttrValue := showOnlyAttr.([]interface{})
 
 		for _, showFile := range showOnlyAttrValue {
-			showFiles = append(showFiles, showFile.(string))
+			if showFile != nil {
+				showFiles = append(showFiles, showFile.(string))
+			}
 		}
 	}
 

--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -375,8 +375,8 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		showOnlyAttrValue := showOnlyAttr.([]interface{})
 
 		for _, showFile := range showOnlyAttrValue {
-			if showFile != nil {
-				showFiles = append(showFiles, showFile.(string))
+			if s, ok := showFile.(string); ok {
+				showFiles = append(showFiles, s)
 			}
 		}
 	}

--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -375,7 +375,7 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		showOnlyAttrValue := showOnlyAttr.([]interface{})
 
 		for _, showFile := range showOnlyAttrValue {
-			if s, ok := showFile.(string); ok {
+			if s, ok := showFile.(string); ok && len(s) > 0 {
 				showFiles = append(showFiles, s)
 			}
 		}

--- a/helm/data_template_test.go
+++ b/helm/data_template_test.go
@@ -82,34 +82,10 @@ data:
 	})
 }
 
-func TestAccDataTemplate_emptyShowOnly(t *testing.T) {
-	name := randName("basic")
-	namespace := randName(testNamespacePrefix)
-
-	datasourceAddress := fmt.Sprintf("data.helm_template.%s", testResourceName)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{{
-			Config: testAccDataHelmTemplateConfigEmptyShowOnly(testResourceName, namespace, name, "1.2.3"),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr(datasourceAddress, "manifests.%", "5"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/deployment.yaml"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/service.yaml"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/serviceaccount.yaml"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/configmaps.yaml"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/tests/test-connection.yaml"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "manifest"),
-				resource.TestCheckResourceAttrSet(datasourceAddress, "notes"),
-			),
-		}},
-	})
-}
-
 func testAccDataHelmTemplateConfigBasic(resource, ns, name, version string) string {
 	return fmt.Sprintf(`
 		data "helm_template" "%s" {
+			show_only	= [""]
  			name        = %q
 			namespace   = %q
 			description = "Test"
@@ -152,31 +128,8 @@ func testAccDataHelmTemplateConfigTemplates(resource, ns, name, version string) 
 
 			show_only = [
 				"templates/configmaps.yaml",
+				""
 			]
-		}
-	`, resource, name, ns, testRepositoryURL, version)
-}
-
-func testAccDataHelmTemplateConfigEmptyShowOnly(resource, ns, name, version string) string {
-	return fmt.Sprintf(`
-		data "helm_template" "%s" {
-			show_only	= [""]
- 			name        = %q
-			namespace   = %q
-			description = "Test"
-			repository  = %q
-  			chart       = "test-chart"
-			version     = %q
-
-			set {
-				name = "foo"
-				value = "bar"
-			}
-
-			set {
-				name = "fizz"
-				value = 1337
-			}
 		}
 	`, resource, name, ns, testRepositoryURL, version)
 }

--- a/helm/data_template_test.go
+++ b/helm/data_template_test.go
@@ -82,6 +82,31 @@ data:
 	})
 }
 
+func TestAccDataTemplate_emptyShowOnly(t *testing.T) {
+	name := randName("basic")
+	namespace := randName(testNamespacePrefix)
+
+	datasourceAddress := fmt.Sprintf("data.helm_template.%s", testResourceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{{
+			Config: testAccDataHelmTemplateConfigEmptyShowOnly(testResourceName, namespace, name, "1.2.3"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(datasourceAddress, "manifests.%", "5"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/deployment.yaml"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/service.yaml"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/serviceaccount.yaml"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/configmaps.yaml"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/tests/test-connection.yaml"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifest"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "notes"),
+			),
+		}},
+	})
+}
+
 func testAccDataHelmTemplateConfigBasic(resource, ns, name, version string) string {
 	return fmt.Sprintf(`
 		data "helm_template" "%s" {
@@ -128,6 +153,30 @@ func testAccDataHelmTemplateConfigTemplates(resource, ns, name, version string) 
 			show_only = [
 				"templates/configmaps.yaml",
 			]
+		}
+	`, resource, name, ns, testRepositoryURL, version)
+}
+
+func testAccDataHelmTemplateConfigEmptyShowOnly(resource, ns, name, version string) string {
+	return fmt.Sprintf(`
+		data "helm_template" "%s" {
+			show_only	= [""]
+ 			name        = %q
+			namespace   = %q
+			description = "Test"
+			repository  = %q
+  			chart       = "test-chart"
+			version     = %q
+
+			set {
+				name = "foo"
+				value = "bar"
+			}
+
+			set {
+				name = "fizz"
+				value = 1337
+			}
 		}
 	`, resource, name, ns, testRepositoryURL, version)
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

fix a crash when setting `show_only`  value to an empty string

Fixes #949 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Fix show_only crash in helm_template
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
