### PR TITLE
Add debug message for cluster unreachable at plan time

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -862,6 +862,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 					// NOTE it would be nice to return a diagnostic here to warn the user
 					// that we can't generate the diff here because the cluster is not yet
 					// reachable but this is not supported by CustomizeDiffFunc
+					debug(`cluster was unreachable at create time, marking "manifest" as computed`)
 					return d.SetNewComputed("manifest")
 				}
 				return err


### PR DESCRIPTION
The CustomizeDiffFunc function doesn't allow us to surface diagnostic messages when something goes wrong, only errors.

We don't want the plan to fail so instead we mark "manifest" as computed and swallow the error, and write a debug log.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
