### PR TITLE
Add support for setting kube version on data.helm_template.

### DIFF
--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -346,6 +346,11 @@ func dataTemplate() *schema.Resource {
 				Computed:    true,
 				Description: "Rendered notes if the chart contains a `NOTES.txt`.",
 			},
+			"kube_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Kubernetes version used for Capabilities.KubeVersion",
+			},
 		},
 	}
 }
@@ -448,6 +453,14 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	client.Replace = d.Get("replace").(bool)
 	client.Description = d.Get("description").(string)
 	client.CreateNamespace = d.Get("create_namespace").(bool)
+
+	if ver := d.Get("kube_version").(string); ver != "" {
+		parsedVer, err := chartutil.ParseKubeVersion(ver)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("couldn't parse string %q into kube-version", ver))
+		}
+		client.KubeVersion = parsedVer
+	}
 
 	// The following source has been adapted from the source of the helm template command
 	// https://github.com/helm/helm/blob/v3.5.3/cmd/helm/template.go#L67

--- a/helm/data_template_test.go
+++ b/helm/data_template_test.go
@@ -109,6 +109,16 @@ func TestAccDataTemplate_kubeVersion(t *testing.T) {
 		}},
 	})
 
+	// Kube Version set but not parsable.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{{
+			Config:      testAccDataHelmTemplateKubeVersion(testResourceName, namespace, name, "1.2.3", "abcdef"),
+			ExpectError: regexp.MustCompile(`couldn't parse string "abcdef" into kube-version`),
+		}},
+	})
+
 	// Kube Version set and above the min version.
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/helm/testdata/charts/kube-version/Chart.yaml
+++ b/helm/testdata/charts/kube-version/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: kube-version
+description: A chart requiring kube version 1.22 or above
+type: application
+version: 1.2.3
+appVersion: 1.2.3
+kubeVersion: ">=1.22.0-0"

--- a/helm/testdata/charts/kube-version/templates/_helpers.tpl
+++ b/helm/testdata/charts/kube-version/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-version.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-version.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-version.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-version.labels" -}}
+helm.sh/chart: {{ include "kube-version.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/helm/testdata/charts/kube-version/templates/deployment.yaml
+++ b/helm/testdata/charts/kube-version/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kube-version.fullname" . }}
+  labels:
+    {{- include "kube-version.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/testdata/charts/kube-version/values.yaml
+++ b/helm/testdata/charts/kube-version/values.yaml
@@ -1,0 +1,49 @@
+# Default values for kube-version.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/website/docs/d/template.html.markdown
+++ b/website/docs/d/template.html.markdown
@@ -155,6 +155,7 @@ The following attributes are specific to the `helm_template` data source and not
 * `is_upgrade` - (Optional) Set .Release.IsUpgrade instead of .Release.IsInstall. Defaults to `false`.
 * `show_only` - (Optional) Explicit list of chart templates to render, as Helm does with the `-s` or `--show-only` option. Paths to chart templates are relative to the root folder of the chart, e.g. `templates/deployment.yaml`. If not provided, all templates of the chart are rendered.
 * `validate` - (Optional) Validate your manifests against the Kubernetes cluster you are currently pointing at. This is the same validation performed on an install. Defaults to `false`.
+* `kube_version` - (Optional) Kubernetes version used for Capabilities.KubeVersion.
 
 ## Attributes Reference
 

--- a/website/docs/d/template.html.markdown
+++ b/website/docs/d/template.html.markdown
@@ -155,7 +155,7 @@ The following attributes are specific to the `helm_template` data source and not
 * `is_upgrade` - (Optional) Set .Release.IsUpgrade instead of .Release.IsInstall. Defaults to `false`.
 * `show_only` - (Optional) Explicit list of chart templates to render, as Helm does with the `-s` or `--show-only` option. Paths to chart templates are relative to the root folder of the chart, e.g. `templates/deployment.yaml`. If not provided, all templates of the chart are rendered.
 * `validate` - (Optional) Validate your manifests against the Kubernetes cluster you are currently pointing at. This is the same validation performed on an install. Defaults to `false`.
-* `kube_version` - (Optional) Kubernetes version used for Capabilities.KubeVersion.
+* `kube_version` - (Optional) Allows specifying a custom kubernetes version to use when templating.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

When using the `helm_template` data source  on a template that has kube version constraints it will fail with an error (unless `v1.20.0`) is within that range.

```text
Error: chart requires kubeVersion: >=1.22.0-0 which is incompatible with Kubernetes v1.20.0
```

So this PR adds the ability to set the kube-version, much like you can with `helm template --kube-version`.

### Usage

```yaml
data "helm_template" "example" {
  name         = "example"
  namespace    = "default"
  repository   = "https://example.com/repo"
  chart        = "example"
  kube_version = "1.22"
}
```

### Acceptance tests

Be able to template where templates require k8s versions > 1.20.0.


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
Ability to specify kube-version when using data source template.
```

### References

Fix: https://github.com/hashicorp/terraform-provider-helm/issues/994

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

