### PR TITLE
Configurable burst_limit

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -101,6 +101,12 @@ func Provider() *schema.Provider {
 					}
 				},
 			},
+			"burst_limit": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     100,
+				Description: "Helm burst limit. Increase this if you have a cluster with many CRDs",
+			},
 			"kubernetes": {
 				Type:        schema.TypeList,
 				MaxItems:    1,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -150,6 +150,7 @@ The following arguments are supported:
 * `repository_cache` - (Optional) The path to the file containing cached repository indexes. Defaults to `HELM_REPOSITORY_CACHE` env if it is set, otherwise uses the default path set by helm.
 * `helm_driver` - (Optional) "The backend storage driver. Valid values are: `configmap`, `secret`, `memory`, `sql`. Defaults to `secret`.
   Note: Regarding the sql driver, as of helm v3.2.0 SQL support exists only for the postgres dialect. The connection string can be configured by setting the `HELM_DRIVER_SQL_CONNECTION_STRING` environment variable e.g. `HELM_DRIVER_SQL_CONNECTION_STRING=postgres://username:password@host/dbname` more info [here](https://pkg.go.dev/github.com/lib/pq).
+* `burst_limit` - (Optional) The helm burst limit to use. Set this value higher if your cluster has many CRDs. Default: `100`
 * `kubernetes` - Kubernetes configuration block.
 * `registry` - Private OCI registry configuration block. Can be specified multiple times.
 


### PR DESCRIPTION
### Description

Add a ` burst_limit`  argument to the provider block to configure the helm client-go connection. The default value is `100` but should be increased in case the cluster you apply to has many CRDs. See #1011 for a more detailed explanation. The CL is large because it includes the required dependabot merge from #1016 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
* Adds the burst_limit argument to configure the Helm client-go burst configuration. Useful for Crossplane enabled clusters
```
### References

Issue describing the problem in detail: #1011  
Related helm issue: https://github.com/helm/helm/issues/10560

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
