### PR TITLE
Compare release values and desired values in resourceDiff

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -964,6 +964,33 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		}
 	}
 
+	desiredValues, err := getValues(d)
+	if err != nil {
+		return err
+	}
+	cloakSetValues(desiredValues, d)
+	desiredValuesJson, err := json.Marshal(desiredValues)
+	if err != nil {
+		return err
+	}
+	desiredValuesJsonString := string(desiredValuesJson)
+
+	if desiredValuesJsonString != d.Get("metadata.0.values").(string) &&
+		!(desiredValuesJsonString == "{}" && d.Get("metadata.0.values").(string) == "null") {
+		err = d.SetNew("metadata", []map[string]interface{}{{
+			"name":        d.Get("metadata.0.name"),
+			"revision":    d.Get("metadata.0.revision").(int),
+			"namespace":   d.Get("metadata.0.namespace"),
+			"chart":       d.Get("metadata.0.chart"),
+			"version":     d.Get("metadata.0.version"),
+			"app_version": d.Get("metadata.0.app_version"),
+			"values":      desiredValuesJsonString,
+		}})
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -953,10 +953,18 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 
 	// Set desired version from the Chart metadata if available
 	if len(chart.Metadata.Version) > 0 {
-		return d.SetNew("version", chart.Metadata.Version)
+		err := d.SetNew("version", chart.Metadata.Version)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := d.SetNewComputed("version")
+		if err != nil {
+			return err
+		}
 	}
 
-	return d.SetNewComputed("version")
+	return nil
 }
 
 func setReleaseAttributes(d *schema.ResourceData, r *release.Release, meta interface{}) error {


### PR DESCRIPTION
### Description

Compare release values and desired values in resourceDiff.
It allow us resync the state between helm release and terraform state when they are inconsistent.
It is useful when the upgrade is failed setting `atomic = true` option that mentioned in #472.

Here is the execution result.
![image](https://user-images.githubusercontent.com/16132835/208708895-ded1d6b5-93f7-47d4-8e57-f79dff41a7af.png)

One side effect is that would always shows the `metadata.values` changes when the values is change, and it may make diff result more longer.

**Note: Currently not support when the changed value is setting by `set_sensitive`, because the value will be formatted to `(sensitive data)`. It is the same in diff. 
We can support `set_sensitive` in later PRs. It can be implemented by set these sensitive values to hash, just like `manifest` does.**

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Compare release values and desired values in resourceDiff
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Fix: #472 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
