### PR TITLE
Add GCS/S3 plugin docs

### DIFF
--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -93,8 +93,9 @@ The provider also supports helm plugins such as GCS and S3 that add S3/GCS helm 
 # Get your chart:
 
 resource "helm_release" "GCS" {
-  name                 = "GCS"
-  chart                = "path/chart"
+  name        = "GCS"
+  repository  = "gcs://tf-test-helm-repo/charts"
+  chart       = "chart"
 }
 ```
 
@@ -119,9 +120,10 @@ resource "helm_release" "GCS" {
 
 # Get your chart:
 
-resource "helm_release" "GCS" {
-  name                 = "GCS"
-  chart                = "path/chart"
+resource "helm_release" "S3" {
+  name        = "S3"
+  repository  = "s3://tf-test-helm-repo/charts"
+  chart       = "chart"
 }
 ```
 

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -67,6 +67,64 @@ resource "helm_release" "example" {
 }
 ```
 
+## Example Usage - Chart Repository configured using GCS/S3
+
+The provider also supports helm plugins such as GCS and S3 that add S3/GCS helm repositories by using `helm plugin install`
+
+```hcl
+
+# Install GCS plugin
+`helm plugin install https://github.com/hayorov/helm-gcs.git`
+
+# Run follow commands to setup GCS repository
+
+# Init a new repository:
+#   helm gcs init gs://bucket/path
+
+# Add your repository to Helm:
+#   helm repo add repo-name gs://bucket/path
+
+# Push a chart to your repository:
+#   helm gcs push chart.tar.gz repo-name
+
+# Update Helm cache:
+#   helm repo update
+
+# Get your chart:
+
+resource "helm_release" "GCS" {
+  name                 = "GCS"
+  chart                = "path/chart"
+}
+```
+
+```hcl
+
+# Install AWS S3 plugin
+`helm plugin install https://github.com/hypnoglow/helm-s3.git`
+
+# Run follow commands to setup S3 repository
+
+# Init a new repository:
+#   helm s3 init s3://my-helm-charts/stable/myapp
+
+# Add your repository to Helm:
+#   helm repo add stable-myapp s3://my-helm-charts/stable/myapp/
+
+# Push a chart to your repository:
+#   helm s3 push chart.tar.gz repo-name
+
+# Update Helm cache:
+#   helm repo update
+
+# Get your chart:
+
+resource "helm_release" "GCS" {
+  name                 = "GCS"
+  chart                = "path/chart"
+}
+```
+
 ## Example Usage - Chart Repository configured outside of Terraform
 
 The provider also supports repositories that are added to the local machine outside of Terraform by running `helm repo add`


### PR DESCRIPTION
### Description

Added how to use helm plugins such as GCS and S3 with helm provider for users that want to pull charts from buckets found in either S3 or GCS

Fixes #613 

<!--- Please leave a helpful description of the pull request here. --->


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
