### PR TITLE
Fixing registry config path usage

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -346,7 +346,10 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		m.HelmDriver = v.(string)
 	}
 
-	if registryClient, err := registry.NewClient(); err == nil {
+	opts := []registry.ClientOption{
+		registry.ClientOptCredentialsFile(settings.RegistryConfig),
+	}
+	if registryClient, err := registry.NewClient(opts...); err == nil {
 		m.RegistryClient = registryClient
 		for _, r := range d.Get("registry").([]interface{}) {
 			if v, ok := r.(map[string]interface{}); ok {


### PR DESCRIPTION
Hello. I want to use this provider with `registry_config_path` redefinition, but it doesn't work as expected. Custom registry config file doesn't use. Can we merge these changes for fixing behaviour?