### PR TITLE
Changing kubectl config path definition behaviour

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,6 +23,8 @@ import (
 
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 // Meta is the meta information structure for the provider
@@ -229,7 +232,7 @@ func kubernetesResource() *schema.Resource {
 			"config_path": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("KUBE_CONFIG_PATH", nil),
+				DefaultFunc:   schema.MultiEnvDefaultFunc([]string{"KUBE_CONFIG_PATH", "KUBECONFIG"}, getDefaultKubeConfigPath()),
 				Description:   "Path to the kube config file. Can be set with KUBE_CONFIG_PATH.",
 				ConflictsWith: []string{"kubernetes.0.config_paths"},
 			},
@@ -501,4 +504,12 @@ func OCIRegistryPerformLogin(registryClient *registry.Client, ociURL string, use
 
 func debug(format string, a ...interface{}) {
 	log.Printf("[DEBUG] %s", fmt.Sprintf(format, a...))
+}
+
+func getDefaultKubeConfigPath() string {
+	return filepath.Join(
+		homedir.HomeDir(),
+		clientcmd.RecommendedHomeDir,
+		clientcmd.RecommendedFileName,
+	)
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -76,7 +76,7 @@ For a full list of supported provider authentication arguments and their corresp
 
 ### File config
 
-The easiest way is to supply a path to your kubeconfig file using the `config_path` attribute or using the `KUBE_CONFIG_PATH` environment variable. A kubeconfig file may have multiple contexts. If `config_context` is not specified, the provider will use the `default` context.
+The easiest way is to supply a path to your kubeconfig file using the `config_path` attribute or using the `KUBE_CONFIG_PATH` or `KUBECONFIG` environment variables. A kubeconfig file may have multiple contexts. If `config_context` is not specified, the provider will use the `default` context.
 
 ```hcl
 provider "helm" {
@@ -155,7 +155,7 @@ The following arguments are supported:
 
 The `kubernetes` block supports:
 
-* `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG_PATH`.
+* `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG_PATH` (or `KUBECONFIG`).
 * `config_paths` - (Optional) A list of paths to the kube config files. Can be sourced from `KUBE_CONFIG_PATHS`.
 * `host` - (Optional) The hostname (in form of URI) of the Kubernetes API. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes API. Can be sourced from `KUBE_USER`.


### PR DESCRIPTION
Hello. I think that it would be good to define kubectl config path from default env var (`KUBECONFIG`) or default path (`~/.kube/config` for example) as options.