### PR TITLE
Add HashiCorp copyright headers

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,15 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2017
+  header_ignore  = [
+    ".changelog/**",
+    ".github/**",
+    ".goreleaser.yml",
+    ".markdownlint.yml",
+    ".release/**",
+    "helm/testdata/**",
+    "vendor/**",
+  ]
+}

--- a/.github/workflows/hc-copywrite.yml
+++ b/.github/workflows/hc-copywrite.yml
@@ -1,0 +1,25 @@
+name: HashiCorp Copywrite
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+    - name: Install copywrite
+      uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce # v1.0.0
+
+    - name: Validate Header Compliance
+      run: copywrite headers --plan

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,9 @@ jobs:
     needs: get_version_matrix
     runs-on: ubuntu-latest
     strategy:
+      # Don't cancel all in-progress and queued jobs in the matrix if any job in the matrix fails.
+      # That will be helpful to catch any issues related to a particular Terraform version.
+      fail-fast: false
       matrix:
         terraform_version:  ${{ fromJson(needs.get_version_matrix.outputs.version_matrix) }}
     steps:


### PR DESCRIPTION
### Description

Add `.copywrite.hcl` configuration file to add HashiCorp copyright to files in the repo.

### Acceptance tests

N/A.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
NONE
```
### References

N/A.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
