### PR TITLE
Always recompute metadata when a release is updated

### DIFF
--- a/.changelog/1097.txt
+++ b/.changelog/1097.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm/resource_release.go`: Always recompute metadata when a release is updated
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1041,9 +1041,13 @@ func setReleaseAttributes(d *schema.ResourceData, r *release.Release, meta inter
 	}
 
 	cloakSetValues(r.Config, d)
-	values, err := json.Marshal(r.Config)
-	if err != nil {
-		return err
+	values := "{}"
+	if r.Config != nil {
+		v, err := json.Marshal(r.Config)
+		if err != nil {
+			return err
+		}
+		values = string(v)
 	}
 
 	m := meta.(*Meta)
@@ -1063,7 +1067,7 @@ func setReleaseAttributes(d *schema.ResourceData, r *release.Release, meta inter
 		"chart":       r.Chart.Metadata.Name,
 		"version":     r.Chart.Metadata.Version,
 		"app_version": r.Chart.Metadata.AppVersion,
-		"values":      string(values),
+		"values":      values,
 	}})
 }
 

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -830,7 +830,13 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 
 	// Always recompute metadata if a new revision is going to be created
 	recomputeMetadataFields := []string{
-		"chart", "repository", "version", "set", "set_sensitive", "values",
+		"chart",
+		"repository",
+		"version",
+		"values",
+		"set",
+		"set_sensitive",
+		"set_list",
 	}
 	if d.HasChanges(recomputeMetadataFields...) {
 		d.SetNewComputed("metadata")

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1041,13 +1041,9 @@ func setReleaseAttributes(d *schema.ResourceData, r *release.Release, meta inter
 	}
 
 	cloakSetValues(r.Config, d)
-	var values []byte
-	if len(r.Config) != 0 {
-		var err error
-		values, err = json.Marshal(r.Config)
-		if err != nil {
-			return err
-		}
+	values, err := json.Marshal(r.Config)
+	if err != nil {
+		return err
 	}
 
 	m := meta.(*Meta)

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -828,6 +828,14 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		return err
 	}
 
+	// Always recompute metadata if a new revision is going to be created
+	recomputeMetadataFields := []string{
+		"chart", "repository", "version", "set", "set_sensitive", "values",
+	}
+	if d.HasChanges(recomputeMetadataFields...) {
+		d.SetNewComputed("metadata")
+	}
+
 	var chartPathOpts action.ChartPathOptions
 	cpo, chartName, err := chartPathOptions(d, m, &chartPathOpts)
 	if err != nil {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1033,9 +1033,13 @@ func setReleaseAttributes(d *schema.ResourceData, r *release.Release, meta inter
 	}
 
 	cloakSetValues(r.Config, d)
-	values, err := json.Marshal(r.Config)
-	if err != nil {
-		return err
+	var values []byte
+	if len(r.Config) != 0 {
+		var err error
+		values, err = json.Marshal(r.Config)
+		if err != nil {
+			return err
+		}
 	}
 
 	m := meta.(*Meta)

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1817,6 +1817,10 @@ func TestAccResourceRelease_recomputeMetadata(t *testing.T) {
 					resource.TestCheckResourceAttr("helm_release.test", "set.0.value", "test"),
 				),
 			},
+			{
+				Config:   testAccHelmReleaseRecomputeMetadataSet(testResourceName, namespace, name),
+				PlanOnly: true,
+			},
 		},
 	})
 }

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1778,7 +1778,7 @@ func TestAccResourceRelease_OCI_login(t *testing.T) {
 	})
 }
 
-func TestAccResourceRelease_computedMetadata(t *testing.T) {
+func TestAccResourceRelease_recomputeMetadata(t *testing.T) {
 	name := randName("basic")
 	namespace := createRandomNamespace(t)
 	defer deleteNamespace(t, namespace)
@@ -1804,14 +1804,17 @@ func TestAccResourceRelease_computedMetadata(t *testing.T) {
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", namespace),
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.1.0"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "2.0.0"),
+					resource.TestCheckResourceAttr("helm_release.test", "set.%", "0"),
 				),
 			},
 			{
 				Config: testAccHelmReleaseRecomputeMetadataSet(testResourceName, namespace, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.1.0"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "2.0.0"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+					resource.TestCheckResourceAttr("helm_release.test", "set.0.name", "test"),
+					resource.TestCheckResourceAttr("helm_release.test", "set.0.value", "test"),
 				),
 			},
 		},
@@ -2073,9 +2076,7 @@ func testAccHelmReleaseRecomputeMetadata(resource, ns, name string) string {
 		resource "helm_release" "%s" {
 			name        = %q
 			namespace   = %q
-			repository          = "https://helm.github.io/examples"
-  chart               = "hello-world"
-  version             = "0.1.0"
+			chart       = "./testdata/charts/test-chart-v2"
 		}
 
 		resource "local_file" "example" {
@@ -2090,10 +2091,8 @@ func testAccHelmReleaseRecomputeMetadataSet(resource, ns, name string) string {
 		resource "helm_release" "%s" {
 			name        = %q
 			namespace   = %q
-			repository          = "https://helm.github.io/examples"
-  chart               = "hello-world"
-  version             = "0.1.0"
-			
+  			chart       = "./testdata/charts/test-chart-v2"
+
 			set {
 				name  = "test"
 				value = "test"
@@ -2103,6 +2102,6 @@ func testAccHelmReleaseRecomputeMetadataSet(resource, ns, name string) string {
 		resource "local_file" "example" {
 			content  = yamlencode(helm_release.test.metadata)
 			filename = "${path.module}/foo.bar"
-		  }
+		}
 `, resource, name, ns)
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Recompute metadata whenever a release is updated, this insures that `metadata` is computed after every release creation

Fixes #1093

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`helm/resource_release.go`: Always recompute metadata when a release is updated
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
