### PR TITLE
Docs: move status attribute out of metadata block support

### DIFF
--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -249,6 +249,7 @@ exported:
 
 * `manifest` - The rendered manifest of the release as JSON. Enable the `manifest` experiment to use this feature.
 * `metadata` - Block status of the deployed release.
+* `status` - Status of the release.
 
 The `metadata` block supports:
 
@@ -256,7 +257,6 @@ The `metadata` block supports:
 * `name` - Name is the name of the release.
 * `namespace` - Namespace is the kubernetes namespace of the release.
 * `revision` - Version is an int32 which represents the version of the release.
-* `status` - Status of the release.
 * `version` - A SemVer 2 conformant version string of the chart.
 * `app_version` - The version number of the application being deployed.
 * `values` - The compounded values from `values` and `set*` attributes.


### PR DESCRIPTION
### Description

This updates the `helm_release` docs to have the `status` attribute not be under the `metadata` block supports.

The status of a helm release can be grabbed with just `helm_release.cert_manager.status`

Fixs #1104 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
