### PR TITLE
Update documentation

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -173,12 +173,12 @@ func registryResource() *schema.Resource {
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+				Description: "The username to use for the OCI HTTP basic authentication when accessing the Kubernetes master endpoint.",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+				Description: "The password to use for the OCI HTTP basic authentication when accessing the Kubernetes master endpoint.",
 			},
 		},
 	}


### PR DESCRIPTION
### Description

We had a confusion about the usage of the credentials in the provider stanza and the release stanza. We thought that the provider stanza will be enough to log in to a (non-OCI) repo with basic auth. But this is not the case. You still need to supply credentials with the release stanze. I hope this change avoids this confusion in the future.

Purely a doc change

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
...
NONE
````
### References

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
