### PR TITLE
resolve version conflicts with local chart

### DIFF
--- a/.changelog/1176.txt
+++ b/.changelog/1176.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm/resource_release.go`: Fix: version conflicts when using local chart 
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1169,9 +1169,11 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 
 	// Checks if chart is a URL; checks if it's a valid URL to a .tgz file of the chart
 	url, err := http.Get(name)
-	contentType := url.Header.Get("Content-Type")
-	if err == nil && contentType != "binary/octet-stream" && contentType != "application/x-gzip" {
-		return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
+	if err == nil {
+		contentType := url.Header.Get("Content-Type")
+		if contentType != "binary/octet-stream" && contentType != "application/x-gzip" {
+			return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
+		}
 	}
 
 	path, err := cpo.LocateChart(name, m.Settings)

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1167,6 +1167,11 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 	m.Lock()
 	defer m.Unlock()
 
+	url, err := http.Get(name)
+	if err == nil && url.Header.Get("Content-Type") != "binary/octet-stream" {
+		return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
+	}
+
 	path, err := cpo.LocateChart(name, m.Settings)
 	if err != nil {
 		return nil, "", err

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1515,11 +1515,15 @@ func valuesKnown(d *schema.ResourceDiff) bool {
 }
 
 func useChartVersion(chart string, repo string) bool {
-	_, urlerr := url.ParseRequestURI(chart)
-
-	if _, err := os.Stat(chart); err == nil || urlerr == nil {
+	// checks if chart is a URL or OCI registry
+	if _, urlerr := url.ParseRequestURI(chart); urlerr == nil && !registry.IsOCI(chart) {
 		return true
 	}
+	// checks if chart is a local chart
+	if _, err := os.Stat(chart); err == nil {
+		return true
+	}
+	// checks if repo is a local chart
 	if _, err := os.Stat(repo); err == nil {
 		return true
 	}

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1528,8 +1528,8 @@ func valuesKnown(d *schema.ResourceDiff) bool {
 func useChartVersion(chart string, repo string) bool {
 	// checks if chart is a URL or OCI registry
 
-	if url, err := http.Get(chart); err == nil && !registry.IsOCI(chart) {
-		return url.Header.Get("Content-Type") == "binary/octet-stream"
+	if _, err := url.ParseRequestURI(chart); err == nil && !registry.IsOCI(chart) {
+		return true
 	}
 	// checks if chart is a local chart
 	if _, err := os.Stat(chart); err == nil {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1172,7 +1172,7 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 	if err == nil {
 		contentType := url.Header.Get("Content-Type")
 
-		if contentType != "binary/octet-stream" && contentType != "application/x-gzip" {
+		if contentType != "binary/octet-stream" && contentType != "application/x-gzip" && contentType != "application/x-compressed-tar" {
 			panic(contentType)
 			return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
 		}

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -840,8 +840,8 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 	if d.HasChanges(recomputeMetadataFields...) {
 		d.SetNewComputed("metadata")
 	}
-	_, err = url.ParseRequestURI(d.Get("repository").(string))
-	if err == nil {
+	_, err = os.Stat(d.Get("chart").(string))
+	if os.IsNotExist(err) {
 
 		if d.HasChange("version") {
 			// only recompute metadata if the version actually changes
@@ -1388,8 +1388,8 @@ func chartPathOptions(d resourceGetter, m *Meta, cpo *action.ChartPathOptions) (
 	cpo.Keyring = d.Get("keyring").(string)
 	cpo.RepoURL = repositoryURL
 	cpo.Verify = d.Get("verify").(bool)
-	_, err := url.ParseRequestURI(cpo.RepoURL)
-	if err == nil || cpo.RepoURL == "" {
+	_, err := os.Stat(chartName)
+	if os.IsNotExist(err) || cpo.RepoURL == "" {
 		cpo.Version = version
 	}
 	cpo.Username = d.Get("repository_username").(string)

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1173,7 +1173,6 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 		contentType := url.Header.Get("Content-Type")
 
 		if contentType != "binary/octet-stream" && contentType != "application/x-gzip" && contentType != "application/x-compressed-tar" {
-			panic(contentType)
 			return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
 		}
 	}

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1167,8 +1167,10 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 	m.Lock()
 	defer m.Unlock()
 
+	// Checks if chart is a URL; checks if it's a valid URL to a .tgz file of the chart
 	url, err := http.Get(name)
-	if err == nil && url.Header.Get("Content-Type") != "binary/octet-stream" {
+	contentType := url.Header.Get("Content-Type")
+	if err == nil && (contentType != "binary/octet-stream" && contentType != "application/x-gzip") {
 		return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
 	}
 

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -841,7 +841,9 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		d.SetNewComputed("metadata")
 	}
 	_, err = os.Stat(d.Get("chart").(string))
-	if os.IsNotExist(err) {
+	_, err1 := os.Stat(d.Get("repository").(string))
+	_, err2 := url.ParseRequestURI(d.Get("chart").(string))
+	if os.IsNotExist(err) && os.IsNotExist(err1) && err2 != nil {
 
 		if d.HasChange("version") {
 			// only recompute metadata if the version actually changes
@@ -1389,7 +1391,9 @@ func chartPathOptions(d resourceGetter, m *Meta, cpo *action.ChartPathOptions) (
 	cpo.RepoURL = repositoryURL
 	cpo.Verify = d.Get("verify").(bool)
 	_, err := os.Stat(chartName)
-	if os.IsNotExist(err) || cpo.RepoURL == "" {
+	_, err1 := os.Stat(cpo.RepoURL)
+	_, err2 := url.ParseRequestURI(d.Get("chart").(string))
+	if os.IsNotExist(err) && os.IsNotExist(err1) && err2 != nil {
 		cpo.Version = version
 	}
 	cpo.Username = d.Get("repository_username").(string)

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -1166,16 +1165,6 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 	//Load function blows up if accessed concurrently
 	m.Lock()
 	defer m.Unlock()
-
-	// Checks if chart is a URL; checks if it's a valid URL to a .tgz file of the chart
-	url, err := http.Get(name)
-	if err == nil {
-		contentType := url.Header.Get("Content-Type")
-
-		if contentType != "binary/octet-stream" && contentType != "application/x-gzip" && contentType != "application/x-compressed-tar" {
-			return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
-		}
-	}
 
 	path, err := cpo.LocateChart(name, m.Settings)
 	if err != nil {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1389,7 +1389,7 @@ func chartPathOptions(d resourceGetter, m *Meta, cpo *action.ChartPathOptions) (
 	cpo.RepoURL = repositoryURL
 	cpo.Verify = d.Get("verify").(bool)
 	_, err := url.ParseRequestURI(cpo.RepoURL)
-	if err == nil {
+	if err == nil || cpo.RepoURL == "" {
 		cpo.Version = version
 	}
 	cpo.Username = d.Get("repository_username").(string)

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -841,7 +841,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		d.SetNewComputed("metadata")
 	}
 
-	if !isLocalChart(d.Get("chart").(string), d.Get("repository").(string)) {
+	if !useChartVersion(d.Get("chart").(string), d.Get("repository").(string)) {
 		if d.HasChange("version") {
 			// only recompute metadata if the version actually changes
 			// chart versioning is not consistent and some will add
@@ -1387,7 +1387,7 @@ func chartPathOptions(d resourceGetter, m *Meta, cpo *action.ChartPathOptions) (
 	cpo.Keyring = d.Get("keyring").(string)
 	cpo.RepoURL = repositoryURL
 	cpo.Verify = d.Get("verify").(bool)
-	if !isLocalChart(chartName, cpo.RepoURL) {
+	if !useChartVersion(chartName, cpo.RepoURL) {
 		cpo.Version = version
 	}
 	cpo.Username = d.Get("repository_username").(string)
@@ -1514,7 +1514,7 @@ func valuesKnown(d *schema.ResourceDiff) bool {
 	return true
 }
 
-func isLocalChart(chart string, repo string) bool {
+func useChartVersion(chart string, repo string) bool {
 	_, urlerr := url.ParseRequestURI(chart)
 
 	if _, err := os.Stat(chart); err == nil || urlerr == nil {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -840,7 +840,8 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 	if d.HasChanges(recomputeMetadataFields...) {
 		d.SetNewComputed("metadata")
 	}
-	if !isLocalChart(d.Get("chart").(string), d.Get("repository").(string)) {
+	repo := d.Get("repository").(string)
+	if !isLocalChart(d.Get("chart").(string), repo) || registry.IsOCI(repo) {
 		if d.HasChange("version") {
 			// only recompute metadata if the version actually changes
 			// chart versioning is not consistent and some will add
@@ -1386,7 +1387,7 @@ func chartPathOptions(d resourceGetter, m *Meta, cpo *action.ChartPathOptions) (
 	cpo.Keyring = d.Get("keyring").(string)
 	cpo.RepoURL = repositoryURL
 	cpo.Verify = d.Get("verify").(bool)
-	if !isLocalChart(chartName, cpo.RepoURL) {
+	if !isLocalChart(chartName, cpo.RepoURL) || registry.IsOCI(repository) {
 		cpo.Version = version
 	}
 	cpo.Username = d.Get("repository_username").(string)

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1170,7 +1170,7 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 	// Checks if chart is a URL; checks if it's a valid URL to a .tgz file of the chart
 	url, err := http.Get(name)
 	contentType := url.Header.Get("Content-Type")
-	if err == nil && (contentType != "binary/octet-stream" && contentType != "application/x-gzip") {
+	if err == nil && contentType != "binary/octet-stream" && contentType != "application/x-gzip" {
 		return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
 	}
 

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -1516,8 +1517,9 @@ func valuesKnown(d *schema.ResourceDiff) bool {
 
 func useChartVersion(chart string, repo string) bool {
 	// checks if chart is a URL or OCI registry
-	if _, urlerr := url.ParseRequestURI(chart); urlerr == nil && !registry.IsOCI(chart) {
-		return true
+
+	if url, err := http.Get(chart); err == nil && !registry.IsOCI(chart) {
+		return url.Header.Get("Content-Type") == "binary/octet-stream"
 	}
 	// checks if chart is a local chart
 	if _, err := os.Stat(chart); err == nil {

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -1171,7 +1171,9 @@ func getChart(d resourceGetter, m *Meta, name string, cpo *action.ChartPathOptio
 	url, err := http.Get(name)
 	if err == nil {
 		contentType := url.Header.Get("Content-Type")
+
 		if contentType != "binary/octet-stream" && contentType != "application/x-gzip" {
+			panic(contentType)
 			return nil, "", fmt.Errorf("Not an absolute URL to the .tgz of the Chart")
 		}
 	}

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -983,7 +983,6 @@ func TestIsLocalChart(t *testing.T) {
 		{chartPath: "./testdata/charts/test-chart", repositoryURL: "", isLocalChart: true},
 		{chartPath: "", repositoryURL: "https://charts.bitnami.com/bitnami", isLocalChart: false},
 		{chartPath: "redis", repositoryURL: "https://charts.bitnami.com/bitnami", isLocalChart: false},
-		{chartPath: "", repositoryURL: "", isLocalChart: false},
 	}
 
 	for i, tc := range tests {

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -987,11 +987,9 @@ func TestIsLocalChart(t *testing.T) {
 
 	for i, tc := range tests {
 		if result := isLocalChart(tc.chartPath, tc.repositoryURL); result != tc.isLocalChart {
-			t.Fatalf("[%v] error in isLocalChart; expected %v, got %v", i, tc.isLocalChart, result)
+			t.Fatalf("[%v] error in isLocalChart; expected isLocalChart(%q, %q) == %v, got %v", i, tc.chartPath, tc.repositoryURL, tc.isLocalChart, result)
 		}
 	}
-
-	return
 }
 
 func TestGetListValues(t *testing.T) {

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -993,12 +993,12 @@ func TestUseChartVersion(t *testing.T) {
 		// when the repo is an OCI registry
 		{chartPath: "redis", repositoryURL: "oci://registry-1.docker.io/bitnamicharts", useChartVersion: false},
 		// when the chart is a URL to an OCI registry
-		{chartPath: "oci://registry-1.docker.io/bitnamicharts/redis", repositoryURL: "", useChartVersion: true},
+		{chartPath: "oci://registry-1.docker.io/bitnamicharts/redis", repositoryURL: "", useChartVersion: false},
 	}
 
 	for i, tc := range tests {
 		if result := useChartVersion(tc.chartPath, tc.repositoryURL); result != tc.useChartVersion {
-			t.Fatalf("[%v] error in isLocalChart; expected isLocalChart(%q, %q) == %v, got %v", i, tc.chartPath, tc.repositoryURL, tc.useChartVersion, result)
+			t.Fatalf("[%v] error in useChartVersion; expected useChartVersion(%q, %q) == %v, got %v", i, tc.chartPath, tc.repositoryURL, tc.useChartVersion, result)
 		}
 	}
 }

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -971,23 +971,34 @@ func TestGetValuesString(t *testing.T) {
 	}
 }
 
-func TestIsLocalChart(t *testing.T) {
+func TestUseChartVersion(t *testing.T) {
 
 	type test struct {
-		chartPath     string
-		repositoryURL string
-		isLocalChart  bool
+		chartPath       string
+		repositoryURL   string
+		useChartVersion bool
 	}
 
 	tests := []test{
-		{chartPath: "./testdata/charts/test-chart", repositoryURL: "", isLocalChart: true},
-		{chartPath: "", repositoryURL: "https://charts.bitnami.com/bitnami", isLocalChart: false},
-		{chartPath: "redis", repositoryURL: "https://charts.bitnami.com/bitnami", isLocalChart: false},
+		// when chart is a local directory
+		{chartPath: "./testdata/charts/test-chart", repositoryURL: "", useChartVersion: true},
+		// when the repo is a local directory
+		{chartPath: "testchart", repositoryURL: "./testdata/charts", useChartVersion: true},
+		// when the repo is a repository URL
+		{chartPath: "", repositoryURL: "https://charts.bitnami.com/bitnami", useChartVersion: false},
+		// when chartPath is chart name and repo is repository URL
+		{chartPath: "redis", repositoryURL: "https://charts.bitnami.com/bitnami", useChartVersion: false},
+		// when the chart is a URL to an .tgz file
+		{chartPath: "https://charts.bitnami.com/bitnami/redis-10.7.16.tgz", repositoryURL: "", useChartVersion: true},
+		// when the repo is an OCI registry
+		{chartPath: "redis", repositoryURL: "oci://registry-1.docker.io/bitnamicharts", useChartVersion: false},
+		// when the chart is a URL to an OCI registry
+		{chartPath: "oci://registry-1.docker.io/bitnamicharts/redis", repositoryURL: "", useChartVersion: true},
 	}
 
 	for i, tc := range tests {
-		if result := isLocalChart(tc.chartPath, tc.repositoryURL); result != tc.isLocalChart {
-			t.Fatalf("[%v] error in isLocalChart; expected isLocalChart(%q, %q) == %v, got %v", i, tc.chartPath, tc.repositoryURL, tc.isLocalChart, result)
+		if result := useChartVersion(tc.chartPath, tc.repositoryURL); result != tc.useChartVersion {
+			t.Fatalf("[%v] error in isLocalChart; expected isLocalChart(%q, %q) == %v, got %v", i, tc.chartPath, tc.repositoryURL, tc.useChartVersion, result)
 		}
 	}
 }

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -788,20 +788,18 @@ func TestAccResourceRelease_LocalVersion(t *testing.T) {
 	resource "helm_release" "test" {
 		name             = %q
 		namespace        = %q
-		repository       = %q
-		chart            = "test-chart"
+		chart            = "testdata/charts/test-chart"
 		create_namespace = true
-	}`, name, namespace, testRepositoryURL)
+	}`, name, namespace)
 
 	config2 := fmt.Sprintf(`
 	resource "helm_release" "test" {
 		name             = %q
 		namespace        = %q
-		repository       = %q
 		version 		 = "1.0.0"
-		chart            = "test-chart"
+		chart            = "testdata/charts/test-chart"
 		create_namespace = true
-	}`, name, namespace, testRepositoryURL)
+	}`, name, namespace)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -817,7 +815,7 @@ func TestAccResourceRelease_LocalVersion(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					checkResourceAttrExists("helm_release.test.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
 				),
 			},
 			{
@@ -825,7 +823,7 @@ func TestAccResourceRelease_LocalVersion(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					checkResourceAttrExists("helm_release.test.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
 				),
 			},
 		},
@@ -985,6 +983,7 @@ func TestIsLocalChart(t *testing.T) {
 		{chartPath: "./testdata/charts/test-chart", repositoryURL: "", isLocalChart: true},
 		{chartPath: "", repositoryURL: "https://charts.bitnami.com/bitnami", isLocalChart: false},
 		{chartPath: "redis", repositoryURL: "https://charts.bitnami.com/bitnami", isLocalChart: false},
+		{chartPath: "", repositoryURL: "", isLocalChart: false},
 	}
 
 	for i, tc := range tests {

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -990,6 +990,8 @@ func TestUseChartVersion(t *testing.T) {
 		{chartPath: "redis", repositoryURL: "https://charts.bitnami.com/bitnami", useChartVersion: false},
 		// when the chart is a URL to an .tgz file
 		{chartPath: "https://charts.bitnami.com/bitnami/redis-10.7.16.tgz", repositoryURL: "", useChartVersion: true},
+		// when user supplies full URL chart link as chartPath
+		{chartPath: "https://charts.bitnami.com/bitnami/redis", repositoryURL: "", useChartVersion: false},
 		// when the repo is an OCI registry
 		{chartPath: "redis", repositoryURL: "oci://registry-1.docker.io/bitnamicharts", useChartVersion: false},
 		// when the chart is a URL to an OCI registry

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -988,10 +988,8 @@ func TestUseChartVersion(t *testing.T) {
 		{chartPath: "", repositoryURL: "https://charts.bitnami.com/bitnami", useChartVersion: false},
 		// when chartPath is chart name and repo is repository URL
 		{chartPath: "redis", repositoryURL: "https://charts.bitnami.com/bitnami", useChartVersion: false},
-		// when the chart is a URL to an .tgz file
+		// when the chart is a URL to an .tgz file, any other url link that is not a .tgz file will not reach useChartVersion
 		{chartPath: "https://charts.bitnami.com/bitnami/redis-10.7.16.tgz", repositoryURL: "", useChartVersion: true},
-		// when user supplies full URL chart link as chartPath
-		{chartPath: "https://charts.bitnami.com/bitnami/redis", repositoryURL: "", useChartVersion: false},
 		// when the repo is an OCI registry
 		{chartPath: "redis", repositoryURL: "oci://registry-1.docker.io/bitnamicharts", useChartVersion: false},
 		// when the chart is a URL to an OCI registry


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

This PR checks the `repository` value to see whether it's a path or a URL. This would prevent conflicts with the version attribute since the expected action is to have the `version` attribute match the chart version if done locally.

Having a local chart will prevent the use of the `version` attribute so that no diff is shown.

Fixes #1157

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
```
 mau@mau-JKDT676NCP  ~/Dev/terraform-provider-helm   local-chart-verion ● ⍟2  make testacc TESTARGS="-run TestAccResourceRelease_LocalVersion"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run TestAccResourceRelease_LocalVersion -timeout 10m
2023/07/27 09:55:23 Building chart repository...
2023/07/27 09:55:23 Created repository package for "broken-chart"
2023/07/27 09:55:23 Created repository package for "crds-chart"
2023/07/27 09:55:23 Created repository package for "dependency-bar"
2023/07/27 09:55:23 Created repository package for "dependency-foo"
2023/07/27 09:55:23 Created repository package for "failed-deploy"
2023/07/27 09:55:24 Created repository package for "kube-version"
2023/07/27 09:55:24 Created repository package for "test-chart"
2023/07/27 09:55:24 Created repository package for "test-chart-v2"
2023/07/27 09:55:24 Created repository package for "umbrella-chart"
2023/07/27 09:55:24 Built chart repository index
2023/07/27 09:55:24 Test repository is listening on http://localhost:55557
=== RUN   TestAccResourceRelease_LocalVersion
--- PASS: TestAccResourceRelease_LocalVersion (9.16s)
PASS
ok      github.com/hashicorp/terraform-provider-helm/helm       10.609s
```
```
 mau@mau-JKDT676NCP  ~/Dev/terraform-provider-helm   local-chart-verion ⍟3  make testacc TESTARGS="-run TestUseChartVersion"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run TestUseChartVersion -timeout 10m
2023/08/03 11:54:11 Building chart repository...
2023/08/03 11:54:11 Created repository package for "broken-chart"
2023/08/03 11:54:11 Created repository package for "crds-chart"
2023/08/03 11:54:11 Created repository package for "dependency-bar"
2023/08/03 11:54:11 Created repository package for "dependency-foo"
2023/08/03 11:54:11 Created repository package for "failed-deploy"
2023/08/03 11:54:11 Created repository package for "kube-version"
2023/08/03 11:54:11 Created repository package for "test-chart"
2023/08/03 11:54:11 Created repository package for "test-chart-v2"
2023/08/03 11:54:11 Created repository package for "umbrella-chart"
2023/08/03 11:54:12 Built chart repository index
2023/08/03 11:54:12 Test repository is listening on http://localhost:56084
=== RUN   TestUseChartVersion
--- PASS: TestUseChartVersion (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-helm/helm     1.113s
```


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:bug
`helm/resource_release.go`: Fix: version conflicts when using local chart 
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
