### PR TITLE
Add 'name' field validation to be limited to 53 characters

### DIFF
--- a/.changelog/1228.txt
+++ b/.changelog/1228.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/helm_release`: add `name` field validation to be limited to 53 characters.
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -70,10 +70,11 @@ func resourceRelease() *schema.Resource {
 		CustomizeDiff: resourceDiff,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Release name.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 53),
+				Description:  "Release name.",
 			},
 			"repository": {
 				Type:        schema.TypeString,

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -74,7 +74,7 @@ func resourceRelease() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 53),
-				Description:  "Release name.",
+				Description:  "Release name. The length must not be longer than 53 characters.",
 			},
 			"repository": {
 				Type:        schema.TypeString,

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -609,6 +609,28 @@ func TestAccResourceRelease_updateSetValue(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_validation(t *testing.T) {
+	invalidName := "this-helm-release-name-is-longer-than-53-characters-long"
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"helm": func() (*schema.Provider, error) {
+				return Provider(), nil
+			},
+		},
+		CheckDestroy: testAccCheckHelmReleaseDestroy(namespace),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccHelmReleaseConfigBasic(testResourceName, namespace, invalidName, "1.2.3"),
+				ExpectError: regexp.MustCompile("expected length of name to be in the range.*"),
+			},
+		},
+	})
+}
+
 func checkResourceAttrExists(name, key string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ms := s.RootModule()

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -173,7 +173,7 @@ resource "helm_release" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Release name.
+* `name` - (Required) Release name. The length must not be longer than 53 characters.
 * `chart` - (Required) Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended.
 * `repository` - (Optional) Repository URL where to locate the requested chart.
 * `repository_key_file` - (Optional) The repositories cert key file


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?

```console
$ make testacc TESTARGS="-count 1 -run 'TestAccResourceRelease_validation'"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -count 1 -run 'TestAccResourceRelease_validation' -timeout 10m
...
=== RUN   TestAccResourceRelease_validation
--- PASS: TestAccResourceRelease_validation (0.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-helm/helm	1.357s
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
`resource/helm_release`: add `name` field validation to be limited to 53 characters.
```
### References

Fix: https://github.com/hashicorp/terraform-provider-helm/issues/1224

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment