### PR TITLE
Update helm release documentation

### DIFF
--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -219,7 +219,7 @@ The `set`, `set_list`, and `set_sensitive` blocks support:
 * `value` - (Required) value of the variable to be set.
 * `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
 
-Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to  escape certain characters twice in order for it to be parsed. `name` should also be the path that leads to the desired value, where `value` is the desired value that will be set.
+Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to  escape the `{}`, `[]`, and `,` characters twice in order for it to be parsed. `name` should also be the path that leads to the desired value, where `value` is the desired value that will be set.
 
 ```hcl
 set {

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -219,11 +219,11 @@ The `set`, `set_list`, and `set_sensitive` blocks support:
 * `value` - (Required) value of the variable to be set.
 * `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
 
-Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to  escape the `{}`, `[]`, and `,` characters twice in order for it to be parsed. `name` should also be the path that leads to the desired value, where `value` is the desired value that will be set.
+Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to  escape the `{}`, `[]`, `.`, and `,` characters twice in order for it to be parsed. `name` should also be set to the `value path`, and `value` is the desired value that will be set.
 
 ```hcl
 set {
-  name  = "grafana.ingress.annotations\\.alb\\.ingress\\.kubernetes\\.io/group\\.name"
+  name  = "grafana.ingress.annotations.alb\\.ingress\\.kubernetes\\.io/group\\.name"
   value = "shared-ingress"
 }
 ```
@@ -235,12 +235,24 @@ set_list {
 }
 ```
 
+```hcl
+controller:
+  pod:
+    annotations:
+      status.kubernetes.io/restart-on-failure: {"timeout": "30s"}
+```
+
+```hcl
+set {
+    name  = "controller.pod.annotations.status\\.kubernetes\\.io/restart-on-failure"
+    value = "\\{\"timeout\": \"30s\"\\}"
+}
+```
+
 The `postrender` block supports two attributes:
 
 * `binary_path` - (Required) relative or full path to command binary.
 * `args` - (Optional) a list of arguments to supply to the post-renderer.
-
-
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

This PR updates the `helm_release` resource documentation - set argument requires comma escaping on strings.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
