### PR TITLE
Redact sensitive values in arrays

### DIFF
--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1138,6 +1138,35 @@ func TestCloakSetValuesNested(t *testing.T) {
 	}
 }
 
+func TestCloakSetValuesNestedWithArray(t *testing.T) {
+	d := resourceRelease().Data(nil)
+	err := d.Set("set_sensitive", []interface{}{
+		map[string]interface{}{"name": "foo.qux[0].bar", "value": "42"},
+	})
+	if err != nil {
+		t.Fatalf("error setting values: %v", err)
+	}
+
+	barMap := map[string]interface{}{
+		"bar": "bar",
+	}
+
+	qux := []interface{}{
+		barMap,
+	}
+
+	values := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"qux": qux,
+		},
+	}
+
+	cloakSetValues(values, d)
+	if barMap["bar"] != sensitiveContentValue {
+		t.Fatalf("error cloak values, expected %q, got %s", sensitiveContentValue, barMap["bar"])
+	}
+}
+
 func TestCloakSetValuesNotMatching(t *testing.T) {
 	d := resourceRelease().Data(nil)
 	err := d.Set("set_sensitive", []interface{}{


### PR DESCRIPTION
### Description

When using `set_sensitive` no array values get redacted properly (as shown in the added test.) This updates cloakSetValue to iterate arbitrary nested structures and properly redact values.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixed issue with not redacting array values when using `set_sensitive`.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
