### PR TITLE
Fix manifest diffs for OCI charts

### DIFF
--- a/.changelog/1326.txt
+++ b/.changelog/1326.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`provider`: Fix manifest diff rendering for OCI charts.
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -856,8 +856,9 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		}
 	}
 
-	var chartPathOpts action.ChartPathOptions
-	cpo, chartName, err := chartPathOptions(d, m, &chartPathOpts)
+	client := action.NewInstall(actionConfig)
+
+	cpo, chartName, err := chartPathOptions(d, m, &client.ChartPathOptions)
 	if err != nil {
 		return err
 	}
@@ -865,7 +866,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 	// Get Chart metadata, if we fail - we're done
 	chart, path, err := getChart(d, meta.(*Meta), chartName, cpo)
 	if err != nil {
-		return nil
+		return err
 	}
 	debug("%s Got chart", logID)
 


### PR DESCRIPTION
### Description

Fixes https://github.com/hashicorp/terraform-provider-helm/issues/1325.

The OCI registry client wasn't properly initialized in this code path for OCI charts.

This also changes error handling so failures to fetch the chart aren't silent in the future.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:bug
`provider`: Fix manifest diff rendering for OCI charts.
```

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

https://github.com/hashicorp/terraform-provider-helm/issues/1325

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
