### PR TITLE
Use templatefile() instead of "template_file" provider in GKE example

### DIFF
--- a/helm/test-infra/gke/main.tf
+++ b/helm/test-infra/gke/main.tf
@@ -63,10 +63,8 @@ resource "google_container_cluster" "primary" {
   }
 }
 
-data "template_file" "kubeconfig" {
-  template = "${file("${path.module}/kubeconfig-template.yaml")}"
-
-  vars = {
+resource "local_file" "kubeconfig" {
+  content  = templatefile("${path.module}/kubeconfig-template.yaml",{
     cluster_name    = "${google_container_cluster.primary.name}"
     user_name       = "${google_container_cluster.primary.master_auth.0.username}"
     user_password   = "${google_container_cluster.primary.master_auth.0.password}"
@@ -74,11 +72,7 @@ data "template_file" "kubeconfig" {
     cluster_ca      = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
     client_cert     = "${google_container_cluster.primary.master_auth.0.client_certificate}"
     client_cert_key = "${google_container_cluster.primary.master_auth.0.client_key}"
-  }
-}
-
-resource "local_file" "kubeconfig" {
-  content  = "${data.template_file.kubeconfig.rendered}"
+  })
   filename = "${var.kube_config_dir}/config"
 }
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #1327

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
