### PR TITLE
Allow Helm lookup in manifest experiment

### DIFF
--- a/.changelog/1335.txt
+++ b/.changelog/1335.txt
@@ -1,0 +1,3 @@
+```release-note: enhancement
+`resource/helm_release`: enable helm lockup function.
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -927,6 +927,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 			install := action.NewInstall(actionConfig)
 			install.ChartPathOptions = *cpo
 			install.DryRun = true
+			install.DryRunOption = "server"
 			install.DisableHooks = d.Get("disable_webhooks").(bool)
 			install.Wait = d.Get("wait").(bool)
 			install.WaitForJobs = d.Get("wait_for_jobs").(bool)
@@ -993,6 +994,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		upgrade.Timeout = time.Duration(d.Get("timeout").(int)) * time.Second
 		upgrade.Wait = d.Get("wait").(bool)
 		upgrade.DryRun = true // do not apply changes
+		upgrade.DryRunOption = "server"
 		upgrade.DisableHooks = d.Get("disable_webhooks").(bool)
 		upgrade.Atomic = d.Get("atomic").(bool)
 		upgrade.SubNotes = d.Get("render_subchart_notes").(bool)


### PR DESCRIPTION
### Description

This fix is for the "manifest" experiment.

Some charts (notably `aws-load-balancer-controller`) depend on Helm's [lookup](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function) function to get data from certain resources. Often if they cannot get this data, they will generate new data (ex: a UUID). In this case, this will cause a permanent diff and you will not be able to upgrade the chart, since the plan will always change, resulting in a "Provider produced inconsistent final plan" error.

To resolve this, I set the "DryRunOption" to "server". According to [Helm's docs](https://helm.sh/docs/chart_template_guide/debugging/):
> Setting `--dry-run==server` will additionally execute any lookup in your chart towards the server.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
^ No, but I have tested the change manually.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
#805 
#711 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
