### PR TITLE
feat: support Helm DeletionPropagation in Uninstall

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -72,6 +72,7 @@ type HelmReleaseModel struct {
 	Chart                    types.String     `tfsdk:"chart"`
 	CleanupOnFail            types.Bool       `tfsdk:"cleanup_on_fail"`
 	CreateNamespace          types.Bool       `tfsdk:"create_namespace"`
+	DeletionPropagation      types.String     `tfsdk:"deletion_propagation"`
 	DependencyUpdate         types.Bool       `tfsdk:"dependency_update"`
 	Description              types.String     `tfsdk:"description"`
 	Devel                    types.Bool       `tfsdk:"devel"`
@@ -119,6 +120,7 @@ var defaultAttributes = map[string]interface{}{
 	"atomic":                     false,
 	"cleanup_on_fail":            false,
 	"create_namespace":           false,
+	"deletion_propagation":       "background",
 	"dependency_update":          false,
 	"disable_crd_hooks":          false,
 	"disable_openapi_validation": false,
@@ -282,6 +284,14 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:    true,
 				Default:     booldefault.StaticBool(defaultAttributes["create_namespace"].(bool)),
 				Description: "Create the namespace if it does not exist",
+			},
+			"deletion_propagation": schema.StringAttribute{
+				Optional:    true,
+				Default:     stringdefault.StaticString(defaultAttributes["deletion_propagation"].(string)),
+				Description: "Propagation policy for deleting resources. Must be one of: foreground, background, orphan, or unspecified.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("background", "foreground", "orphan"),
+				},
 			},
 			"dependency_update": schema.BoolAttribute{
 				Optional:    true,
@@ -1118,6 +1128,7 @@ func (r *HelmRelease) Delete(ctx context.Context, req resource.DeleteRequest, re
 	uninstall.Wait = state.Wait.ValueBool()
 	uninstall.DisableHooks = state.DisableWebhooks.ValueBool()
 	uninstall.Timeout = time.Duration(state.Timeout.ValueInt64()) * time.Second
+	uninstall.DeletionPropagation = state.DeletionPropagation.ValueString()
 
 	// Uninstall the release
 	tflog.Info(ctx, fmt.Sprintf("Uninstalling Helm release: %s", name))


### PR DESCRIPTION
### Description

This PR aims to fix #1363

By passing through the `DeletionPropagation` value down to the Helm library, we can support the foreground cascading deletion feature of Kubernetes.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

TODO

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`helm_release`: Add `deletion_propagation` property to control Kubernetes Cascading Deletion behaviour.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
