### PR TITLE
Add support for labeling a release

### DIFF
--- a/.changelog/1372.txt
+++ b/.changelog/1372.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add support for labeling a release
+```


### PR DESCRIPTION
Fixes #1323 

### Description

<!--- Please leave a helpful description of the pull request here. --->

Support labeling a release, note the quirk on having to set it to `null` when removing a label.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note:improvement
Add support for labelling a release
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

* https://github.com/hashicorp/terraform-provider-helm/issues/1323
* https://github.com/helm/helm/blob/691f313442d84112c3c9b700e156eef7509f6614/pkg/action/upgrade.go#L630

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
