### PR TITLE
Add new fields to release metadata, fix issue with test suite

### DIFF
--- a/.changelog/1380.txt
+++ b/.changelog/1380.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`helm_release`: add new attributes metadata.last_deployed, metadata.first_deployed, metadata.notes
+```

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -123,7 +123,10 @@ Read-Only:
 - `chart` (String)
 - `name` (String)
 - `namespace` (String)
-- `revision` (Number)
+- `first_deployed` (Number) timestamp when the release was first deployed
+- `last_deployed` (Number) timestamp when the release was last deployed
+- `revision` (Number) version of the release last deployed
+- `notes` (String) rendered templates/NOTES.txt if available
 - `values` (String)
 - `version` (String)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
+	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/hashicorp/terraform-plugin-testing v1.8.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -87,7 +88,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.23.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/helm/provider_test.go
+++ b/helm/provider_test.go
@@ -138,7 +138,7 @@ func buildChartRepository() {
 
 	// package all the charts
 	for _, c := range charts {
-		cmd := exec.Command("helm", "package", "-u",
+		cmd := exec.Command("helm", "--kubeconfig", os.Getenv("KUBE_CONFIG_PATH"), "package", "-u",
 			filepath.Join(testChartsPath, c.Name()),
 			"-d", testRepositoryDir)
 		out, err := cmd.CombinedOutput()
@@ -151,7 +151,7 @@ func buildChartRepository() {
 	}
 
 	// build the repository index
-	cmd := exec.Command("helm", "repo", "index", testRepositoryDir)
+	cmd := exec.Command("helm", "--kubeconfig", os.Getenv("KUBE_CONFIG_PATH"), "repo", "index", testRepositoryDir)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println(string(out))

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -421,6 +421,21 @@ func resourceRelease() *schema.Resource {
 							Computed:    true,
 							Description: "The version number of the application being deployed.",
 						},
+						"first_deployed": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "FirstDeployed is an int32 which represents timestamp when the release was first deployed.",
+						},
+						"last_deployed": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "LastDeployed is an int32 which represents timestamp when the release was last deployed.",
+						},
+						"notes": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Contains the rendered templates/NOTES.txt if available",
+						},
 						"values": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -1081,13 +1096,16 @@ func setReleaseAttributes(d *schema.ResourceData, r *release.Release, meta inter
 	}
 
 	return d.Set("metadata", []map[string]interface{}{{
-		"name":        r.Name,
-		"revision":    r.Version,
-		"namespace":   r.Namespace,
-		"chart":       r.Chart.Metadata.Name,
-		"version":     r.Chart.Metadata.Version,
-		"app_version": r.Chart.Metadata.AppVersion,
-		"values":      values,
+		"name":           r.Name,
+		"revision":       r.Version,
+		"namespace":      r.Namespace,
+		"chart":          r.Chart.Metadata.Name,
+		"version":        r.Chart.Metadata.Version,
+		"app_version":    r.Chart.Metadata.AppVersion,
+		"first_deployed": r.Info.FirstDeployed.Time.Unix(),
+		"last_deployed":  r.Info.LastDeployed.Time.Unix(),
+		"notes":          r.Info.Notes,
+		"values":         values,
 	}})
 }
 


### PR DESCRIPTION
1. Add new computed fields to helm_release.metadata:
   - last_deployed to implement #1374
   - first_deployed and notes to extend functionality further
2. Fix issue with tests that are using exec.Command to call helm CLI directly - they were expecting kubeconfig to be at `$KUBECONFIG`, which may not be the same as `$KUBE_CONFIG_PATH`. The latter is explicitly expected by test suite for Terraform part.



### Description

Exposes more metadata about Helm release to extend the possibilities of other resources to act upon release changes. Additionally, provide primitive output from Helm deployment (rendered templates/NOTES.txt if available), which can be used with some bootstrap process. 

In other words - adding missing data exposed by Helm.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
- add new attributes to helm_release.metadata: last_deployed, first_deployed, notes
- fix uses of helm CLI in tests: explictly use $KUBE_CONFIG_PATH
```
### References

- https://pkg.go.dev/helm.sh/helm/v3@v3.13.2/pkg/release#Info

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
