### PR TITLE
(fix) Allow CRD missing error when computing manifest

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -978,6 +978,10 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 					debug(`cluster was unreachable at create time, marking "manifest" as computed`)
 					return d.SetNewComputed("manifest")
 				}
+				if strings.Contains(err.Error(), "ensure CRDs are installed first") {
+					debug(`some CRDs are not (yet) installed, marking "manifest" as computed`)
+					return d.SetNewComputed("manifest")
+				}
 				return err
 			}
 


### PR DESCRIPTION
### Description

* This PR aims to fix an issue related to the experimental manifest feature

### Issue

When the experimental `manifest` feature is enabled and deploying two charts with a CRD dependency between them (e.g., Chart A installs a new CRD in its manifest, and Chart B declares objects of that CRD), performing terraform plan raises an error. The error occurs in Chart B, stating that the CRD is not yet installed, thus unable to compute its final manifest.

This is not inherently an issue, as the two charts can be installed successfully as long as Chart A is installed before Chart B. This dependency can be managed by setting the depends_on property for Chart B.

### Proposed Solution

* Modify the handling of errors when the `manifest` feature is enabled to allow such errors to not break the planning process.




### References

* Related Issues
  * [Experiments Feature Breaking the helm_release asking for CRD to install First](https://github.com/hashicorp/terraform-provider-helm/issues/1217)
* [Applying CRD and chart on same TF](https://github.com/hashicorp/terraform-provider-helm/issues/976)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
