### PR TITLE
feat: helm dry run server parameter

### DIFF
--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -31,6 +31,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `disable_crd_hooks` (Boolean) Prevent CRD hooks from, running, but run other hooks.  See helm install --no-crd-hook
 - `disable_openapi_validation` (Boolean) If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 - `disable_webhooks` (Boolean) Prevent hooks from running.Defaults to `false`.
+- `dry_run_option` (String) Use "server" to interact with remote apiserver while creating plan. Only used in experimental manifest mode.
 - `force_update` (Boolean) Force resource update through delete/recreate if needed. Defaults to `false`.
 - `keyring` (String) Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`.
 - `lint` (Boolean) Run helm lint when planning. Defaults to `false`.

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -44,6 +44,7 @@ var defaultAttributes = map[string]interface{}{
 	"render_subchart_notes":      true,
 	"disable_openapi_validation": false,
 	"disable_crd_hooks":          false,
+	"dry_run_option":             "",
 	"force_update":               false,
 	"reset_values":               false,
 	"reuse_values":               false,
@@ -249,6 +250,12 @@ func resourceRelease() *schema.Resource {
 				Optional:    true,
 				Default:     defaultAttributes["disable_crd_hooks"],
 				Description: "Prevent CRD hooks from, running, but run other hooks.  See helm install --no-crd-hook",
+			},
+			"dry_run_option": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     defaultAttributes["dry_run_option"],
+				Description: "When executing a dry run to render manifest in experiment mode, render manifest with remote interaction.  See helm install --dry-run=server",
 			},
 			"reuse_values": {
 				Type:        schema.TypeBool,
@@ -942,6 +949,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 			install := action.NewInstall(actionConfig)
 			install.ChartPathOptions = *cpo
 			install.DryRun = true
+			install.DryRunOption = d.Get("dry_run_option").(string)
 			install.DisableHooks = d.Get("disable_webhooks").(bool)
 			install.Wait = d.Get("wait").(bool)
 			install.WaitForJobs = d.Get("wait_for_jobs").(bool)
@@ -1008,6 +1016,7 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 		upgrade.Timeout = time.Duration(d.Get("timeout").(int)) * time.Second
 		upgrade.Wait = d.Get("wait").(bool)
 		upgrade.DryRun = true // do not apply changes
+		upgrade.DryRunOption = d.Get("dry_run_option").(string)
 		upgrade.DisableHooks = d.Get("disable_webhooks").(bool)
 		upgrade.Atomic = d.Get("atomic").(bool)
 		upgrade.SubNotes = d.Get("render_subchart_notes").(bool)


### PR DESCRIPTION
### Description

Helm templates can lookup resources in api server. The dry run mode is not communicating with the remote api server. This has to be enabled with the dry run option "server". This ensures a correct plan when using the lookup functionality.

### Acceptance tests
- [ x ] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note:improvement
helm: Add support for dry run option "server"
```

### References

NONE

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
