### PR TITLE
`CI`: add 1.5, 1.7, 1.9 terraform versions into get-version-matrix

### DIFF
--- a/scripts/get-version-matrix.sh
+++ b/scripts/get-version-matrix.sh
@@ -9,4 +9,4 @@ function get_latest_version() {
             sort -V -r | head -1 
 }
 
-echo "::set-output name=matrix::[$(get_latest_version v0.12), $(get_latest_version v0.13), $(get_latest_version v0.14), $(get_latest_version v0.15), $(get_latest_version v1.0), $(get_latest_version v1.3)]"
+echo "::set-output name=matrix::[$(get_latest_version v0.12), $(get_latest_version v0.13), $(get_latest_version v0.14), $(get_latest_version v0.15), $(get_latest_version v1.0), $(get_latest_version v1.3), $(get_latest_version v1.5), $(get_latest_version v1.7), $(get_latest_version v1.9)]"


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

I noticed that we run our acceptance tests workflow off of a matrix that grabs the matrix values from `get-version-matrix.sh`. the script had the latest version being `TF 1.3` while the latest is `TF 1.9`

This PR updates it so that our acceptance tests are up to date.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
