### PR TITLE
Update documentation section of contribution guide

### DIFF
--- a/_about/PULL_REQUESTS.md
+++ b/_about/PULL_REQUESTS.md
@@ -18,7 +18,7 @@ expect:
    it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests).
    Please include specific questions or items you'd like feedback on. 
 
-1. Our documentation utilizes the `tfplugindocs` tool. When making updates to documentation, please only edit the `.md.tmpl` files and execute the `tfplugindocs generate` command to ensure the changes are reflected in the `.md` files. 
+1. Our documentation utilizes the [`tfplugindocs`](https://github.com/hashicorp/terraform-plugin-docs) tool. When making updates to documentation, please only edit the `.md.tmpl` files and execute the `tfplugindocs generate` command to ensure the changes are reflected in the `.md` files. 
 
 1. Once you believe your pull request is ready to be reviewed, ensure the
    pull request is not a draft pull request by [marking it ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request) and a

--- a/_about/PULL_REQUESTS.md
+++ b/_about/PULL_REQUESTS.md
@@ -16,7 +16,9 @@ expect:
    modify the code, and [create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
    You are welcome to submit your pull request for commentary or review before
    it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests).
-   Please include specific questions or items you'd like feedback on.
+   Please include specific questions or items you'd like feedback on. 
+
+1. Our documentation utilizes the `tfplugindocs` tool. When making updates to documentation, please only edit the `.md.tmpl` files and execute the `tfplugindocs generate` command to ensure the changes are reflected in the `.md` files. 
 
 1. Once you believe your pull request is ready to be reviewed, ensure the
    pull request is not a draft pull request by [marking it ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request) and a


### PR DESCRIPTION
### Description

Add a section on how to use `tfplugindocs` for updating documentation. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
