### PR TITLE
fix: quoting error in check-docs workflow

### DIFF
--- a/.github/workflows/documentation-check.yaml
+++ b/.github/workflows/documentation-check.yaml
@@ -37,6 +37,6 @@ jobs:
   
         - name: Undocumented changes 
           run: |
-            echo "Documentation is not up to date. Please refer to the `Making Changes` in the Contribution Guide on how to properly update documentation."
+            echo 'Documentation is not up to date. Please refer to the `Making Changes` in the Contribution Guide on how to properly update documentation.'
             exit 1
           if: failure()


### PR DESCRIPTION
### Description

Backticks inside double-quotes will be treated as a shell escape.

### Acceptance tests

n/a

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

See discussion in https://github.com/hashicorp/terraform-provider-helm/pull/1247

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
