### PR TITLE
Updating get-version-matrix.sh to use $GITHUB_OUTPUT instead of set-output

### DIFF
--- a/scripts/get-version-matrix.sh
+++ b/scripts/get-version-matrix.sh
@@ -9,4 +9,4 @@ function get_latest_version() {
             sort -V -r | head -1 
 }
 
-echo "::set-output name=matrix::[$(get_latest_version v0.12), $(get_latest_version v0.13), $(get_latest_version v0.14), $(get_latest_version v0.15), $(get_latest_version v1.0), $(get_latest_version v1.3), $(get_latest_version v1.5), $(get_latest_version v1.7), $(get_latest_version v1.9)]"
+echo "matrix=[$(get_latest_version v0.12), $(get_latest_version v0.13), $(get_latest_version v0.14), $(get_latest_version v0.15), $(get_latest_version v1.0), $(get_latest_version v1.3), $(get_latest_version v1.5), $(get_latest_version v1.7), $(get_latest_version v1.9)]" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description
Updating get-version-matrix.sh to use $GITHUB_OUTPUT instead of set-output due to set-output being deprecated
Fixes #1456 

### Acceptance tests
https://github.com/JaylonmcShan03/terraform-provider-helm-gh-actions/actions/runs/10306540967

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
