### PR TITLE
[Plugin framework migration] Fix: use correct split delimiter on KUBE_CONFIG_PATHS value

### DIFF
--- a/helm-framework/helm/provider.go
+++ b/helm-framework/helm/provider.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -87,7 +87,7 @@ type KubernetesConfigModel struct {
 	ConfigContextCluster  types.String `tfsdk:"config_context_cluster"`
 	Token                 types.String `tfsdk:"token"`
 	ProxyUrl              types.String `tfsdk:"proxy_url"`
-	//Exec                  types.List   `tfsdk:"exec"`
+	// Exec                  types.List   `tfsdk:"exec"`
 }
 
 type ExecConfigModel struct {
@@ -173,6 +173,7 @@ func (p *HelmProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 		},
 	}
 }
+
 func experimentsSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"manifest": schema.BoolAttribute{
@@ -181,6 +182,7 @@ func experimentsSchema() map[string]schema.Attribute {
 		},
 	}
 }
+
 func registryResourceSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"url": schema.StringAttribute{
@@ -197,6 +199,7 @@ func registryResourceSchema() map[string]schema.Attribute {
 		},
 	}
 }
+
 func kubernetesResourceSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"host": schema.StringAttribute{
@@ -281,7 +284,6 @@ func kubernetesResourceSchema() map[string]schema.Attribute {
 
 func execSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		//TODO
 		"api_version": schema.StringAttribute{
 			Required:    true,
 			Description: "API version for the exec plugin.",
@@ -423,7 +425,7 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		kubeCaCert = kubernetesConfig.ClusterCaCertificate.ValueString()
 	}
 	if kubeConfigPaths != "" {
-		for _, path := range strings.Split(kubeConfigPaths, ",") {
+		for _, path := range filepath.Split(kubeConfigPaths) {
 			kubeConfigPathsList = append(kubeConfigPathsList, types.StringValue(path))
 		}
 	}


### PR DESCRIPTION
### Description

The `KUBE_CONFIG_PATHS` variable was being split on the `,` character, which is incorrect. We want to split on the system path delimiter, which is actually `:`. Go has a stdlib function for doing this. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
