### PR TITLE
Refactor `ModifyPlan` function in `helm_release.go` (1/2)

### DIFF
--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1736,17 +1736,12 @@ func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.Modif
 	}
 
 	if !useChartVersion(plan.Chart.ValueString(), plan.Repository.ValueString()) {
-		var oldVersion, newVersion attr.Value
-
 		// Check if version has changed
 		if !plan.Version.Equal(state.Version) {
-			// Remove surrounding quotes if they exist
-			oldVersionStr := strings.Trim(oldVersion.String(), "\"")
-			newVersionStr := strings.Trim(newVersion.String(), "\"")
 
 			// Ensure trimming 'v' prefix correctly
-			oldVersionStr = strings.TrimPrefix(oldVersionStr, "v")
-			newVersionStr = strings.TrimPrefix(newVersionStr, "v")
+			oldVersionStr := strings.TrimPrefix(state.Version.String(), "v")
+			newVersionStr := strings.TrimPrefix(plan.Version.String(), "v")
 
 			if oldVersionStr != newVersionStr && newVersionStr != "" {
 				// Setting Metadata to a computed value

--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1738,12 +1738,8 @@ func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.Modif
 	if !useChartVersion(plan.Chart.ValueString(), plan.Repository.ValueString()) {
 		var oldVersion, newVersion attr.Value
 
-		req.Plan.GetAttribute(ctx, path.Root("version"), &newVersion)
-
-		req.State.GetAttribute(ctx, path.Root("version"), &oldVersion)
-
 		// Check if version has changed
-		if !newVersion.Equal(oldVersion) {
+		if !plan.Version.Equal(state.Version) {
 			// Remove surrounding quotes if they exist
 			oldVersionStr := strings.Trim(oldVersion.String(), "\"")
 			newVersionStr := strings.Trim(newVersion.String(), "\"")

--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1789,7 +1789,7 @@ func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.Modif
 
 	if m.ExperimentEnabled("manifest") {
 		// Check if all necessary values are known
-		if !valuesKnown(plan) {
+		if valuesUnknown(plan) {
 			tflog.Debug(ctx, "not all values are known, skipping dry run to render manifest")
 			plan.Manifest = types.StringNull()
 			plan.Version = types.StringNull()
@@ -2150,8 +2150,19 @@ func parseImportIdentifier(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-// returns true if values, set_list, set, set_sensitive are all known
-func valuesKnown(plan HelmReleaseModel) bool {
-	return !plan.Values.IsUnknown() && !plan.Set_list.IsUnknown() &&
-		!plan.Set.IsUnknown() && !plan.Set_Sensitive.IsUnknown()
+// returns true if any values, set_list, set, set_sensitive are unknown
+func valuesUnknown(plan HelmReleaseModel) bool {
+	if plan.Values.IsUnknown() {
+		return true
+	}
+	if plan.Set_list.IsUnknown() {
+		return true
+	}
+	if plan.Set.IsUnknown() {
+		return true
+	}
+	if plan.Set_Sensitive.IsUnknown() {
+		return true
+	}
+	return false
 }

--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1684,7 +1684,6 @@ func (r *HelmReleaseResource) StateUpgrade(ctx context.Context, version int, sta
 	return state, diags
 }
 
-// We just want plan
 func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		// resource is being destroyed
@@ -1718,18 +1717,6 @@ func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.Modif
 	tflog.Debug(ctx, fmt.Sprintf("%s Initial Values: Name=%s, Namespace=%s, Repository=%s, Repository_Username=%s, Repository_Password=%s, Chart=%s", logID,
 		name, namespace, plan.Repository.ValueString(), plan.Repository_Username.ValueString(), plan.Repository_Password.ValueString(), plan.Chart.ValueString()))
 
-	if plan.Repository.IsNull() {
-		tflog.Debug(ctx, fmt.Sprintf("%s Repository is null", logID))
-	}
-	if plan.Repository_Username.IsNull() {
-		tflog.Debug(ctx, fmt.Sprintf("%s Repository_Username is null", logID))
-	}
-	if plan.Repository_Password.IsNull() {
-		tflog.Debug(ctx, fmt.Sprintf("%s Repository_Password is null", logID))
-	}
-	if plan.Chart.IsNull() {
-		tflog.Debug(ctx, fmt.Sprintf("%s Chart is null", logID))
-	}
 	repositoryURL := plan.Repository.ValueString()
 	repositoryUsername := plan.Repository_Username.ValueString()
 	repositoryPassword := plan.Repository_Password.ValueString()

--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1789,7 +1789,7 @@ func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.Modif
 
 	if m.ExperimentEnabled("manifest") {
 		// Check if all necessary values are known
-		if !isValuesKnown(plan) {
+		if !valuesKnown(plan) {
 			tflog.Debug(ctx, "not all values are known, skipping dry run to render manifest")
 			plan.Manifest = types.StringNull()
 			plan.Version = types.StringNull()
@@ -2134,22 +2134,8 @@ func parseImportIdentifier(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-// returns true if values, set_list, set, set_sensitive are known
-func isValuesKnown(plan HelmReleaseModel) bool {
-	return !(isListKnownAndNull(plan.Values) && isListKnownAndNull(plan.Set_list) &&
-		isSetKnownAndNull(plan.Set) && isSetKnownAndNull(plan.Set_Sensitive))
-}
-
-func isListKnownAndNull(list basetypes.ListValue) bool {
-	if !list.IsUnknown() && list.IsNull() {
-		return true
-	}
-	return false
-}
-
-func isSetKnownAndNull(set basetypes.SetValue) bool {
-	if !set.IsUnknown() && set.IsNull() {
-		return true
-	}
-	return false
+// returns true if values, set_list, set, set_sensitive are all known
+func valuesKnown(plan HelmReleaseModel) bool {
+	return !plan.Values.IsUnknown() && !plan.Set_list.IsUnknown() &&
+		!plan.Set.IsUnknown() && !plan.Set_Sensitive.IsUnknown()
 }

--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1983,9 +1983,25 @@ func (r *HelmReleaseResource) ModifyPlan(ctx context.Context, req resource.Modif
 
 // returns true if any metadata fields have changed
 func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
-	return !(plan.Chart.Equal(state.Chart) && plan.Repository.Equal(state.Repository) &&
-		plan.Values.Equal(state.Values) && plan.Set.Equal(state.Set) &&
-		plan.Set_Sensitive.Equal(state.Set_Sensitive) && plan.Set_list.Equal(state.Set_list))
+	if plan.Chart.Equal(state.Chart) {
+		return true
+	}
+	if plan.Repository.Equal(state.Repository) {
+		return true
+	}
+	if plan.Values.Equal(state.Values) {
+		return true
+	}
+	if plan.Set.Equal(state.Set) {
+		return true
+	}
+	if plan.Set_Sensitive.Equal(state.Set_Sensitive) {
+		return true
+	}
+	if plan.Set_list.Equal(state.Set_list) {
+		return true
+	}
+	return false
 }
 
 func resourceReleaseValidate(ctx context.Context, d *HelmReleaseModel, meta *Meta, cpo *action.ChartPathOptions) diag.Diagnostics {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Refactors `ModifyPlan()` method:

1. Removes repetitive log outputs of null values
2. moves logic that checks for metadata fields into it's own `recomputeMetadata`. Uses `plan.Chart.Equal(state.Chart)` instead of relying on `GetAttribute` since metadata fields are in the root.
3. Refactor of `GetAttribute` witihin `chartVersion` condition
4. refactor `valuesKnown` in `ModifyPlan` to also do comparisons of values with `plan.Values` instead of `GetAttribute`

