### PR TITLE
Rename resolveChartName to buildChartNameWithRepository for clarity

### DIFF
--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1131,7 +1131,7 @@ func chartPathOptions(d *HelmReleaseModel, meta *Meta, cpo *action.ChartPathOpti
 		var err error
 		repositoryURL, chartName, err = buildChartNameWithRepository(repository, strings.TrimSpace(chartName))
 		if err != nil {
-			diags.AddError("Error Resolving Chart Name", fmt.Sprintf("Could not resolve chart name for repository %s and chart %s: %s", repository, chartName, err))
+			diags.AddError("Error building Chart Name With Repository", fmt.Sprintf("Could not build Chart Name With Repository %s and chart %s: %s", repository, chartName, err))
 			return nil, "", diags
 		}
 	}

--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1129,7 +1129,7 @@ func chartPathOptions(d *HelmReleaseModel, meta *Meta, cpo *action.ChartPathOpti
 		chartName = u.String()
 	} else {
 		var err error
-		repositoryURL, chartName, err = resolveChartName(repository, strings.TrimSpace(chartName))
+		repositoryURL, chartName, err = buildChartNameWithRepository(repository, strings.TrimSpace(chartName))
 		if err != nil {
 			diags.AddError("Error Resolving Chart Name", fmt.Sprintf("Could not resolve chart name for repository %s and chart %s: %s", repository, chartName, err))
 			return nil, "", diags
@@ -1172,7 +1172,7 @@ func useChartVersion(chart string, repo string) bool {
 	return false
 }
 
-func resolveChartName(repository, name string) (string, string, error) {
+func buildChartNameWithRepository(repository, name string) (string, string, error) {
 	_, err := url.ParseRequestURI(repository)
 	if err == nil {
 		return repository, name, nil


### PR DESCRIPTION
### Description

This PR renames the resolveChartName function to buildChartNameWithRepository to better reflect its purpose. The previous name was misleading as the function doesn't actually "resolve" a chart name but rather constructs or builds the chart name based on the given repository and name. 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
