### PR TITLE
fix: Missing postrender args

### DIFF
--- a/.changelog/1477.txt
+++ b/.changelog/1477.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: Fixed issue with missing postrender arguments
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -665,7 +665,16 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 		upgradeClient.Description = d.Get("description").(string)
 
 		if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-			pr, err := postrender.NewExec(cmd)
+			av := d.Get("postrender.0.args")
+			var args []string
+			for _, arg := range av.([]interface{}) {
+				if arg == nil {
+					continue
+				}
+				args = append(args, arg.(string))
+			}
+
+			pr, err := postrender.NewExec(cmd, args...)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -699,7 +708,16 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 		instClient.CreateNamespace = d.Get("create_namespace").(bool)
 
 		if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-			pr, err := postrender.NewExec(cmd)
+			av := d.Get("postrender.0.args")
+			var args []string
+			for _, arg := range av.([]interface{}) {
+				if arg == nil {
+					continue
+				}
+				args = append(args, arg.(string))
+			}
+
+			pr, err := postrender.NewExec(cmd, args...)
 			if err != nil {
 				return diag.FromErr(err)
 			}


### PR DESCRIPTION
### Description

- When I create helm release with postrender, the script I made can't retrieve args.
- #1503 refer this issue

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
helm_release: Fixed issue with missing postrender arguments
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
