### PR TITLE
Ignore "release: not found" error on helm_resource destroy

### DIFF
--- a/.changelog/1487.txt
+++ b/.changelog/1487.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: On destroy, do not error when release is not found
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -865,7 +865,7 @@ func resourceReleaseDelete(ctx context.Context, d *schema.ResourceData, meta int
 	uninstall.Timeout = time.Duration(d.Get("timeout").(int)) * time.Second
 
 	res, err := uninstall.Run(name)
-	if err != nil {
+	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Description

Ignore "release: not found" error on helm_resource destroy to address [GH-1488](https://github.com/hashicorp/terraform-provider-helm/issues/1488)

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/helm_release: ignore "release not found" destroy error, addressing [GH-1488](https://github.com/hashicorp/terraform-provider-helm/issues/1488)
```
### References
- https://github.com/hashicorp/terraform-provider-helm/issues/1488
- https://helm.sh/docs/helm/helm_uninstall/

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
Closes #1488 
