### PR TITLE
Handle errors during diff stage when using upgrade_mode

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -908,8 +908,10 @@ func resourceDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{})
 	if enableUpgradeStrategy {
 		// Check to see if there is already a release installed.
 		installedVersion, err = getInstalledReleaseVersion(m, actionConfig, name)
+		// because we are in the diff stage, there is no guarantee that the release exists
+		// or even that the _cluster_ exists, so log, leave the installedVersion as "", and continue
 		if err != nil {
-			return err
+			warn("%s could not determine installed version for release '%s': %v", logID, name, err)
 		}
 	}
 


### PR DESCRIPTION
### Description

https://github.com/hashicorp/terraform-provider-helm/pull/1247 introduced a possible order-of-operations bug into `resourceDiff()`: when `upgrade_install` is enabled, `getInstalledReleaseVersion()` is called, but there is no guarantee at this stage that the cluster will even exist.  So instead of failing, log a warning and leave the `installedVersion` variable empty.

### Acceptance tests

I don't think there is a way to simulate a "cluster does not exist" scenario with the current test harness but if I'm missing the obvious please tell me.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* `resource/helm_release`: Fix failure when using `upgrade_install` during cluster creation
```
### References

- none

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
