### PR TITLE
Refactor exec block from List to SingleNestedAttribute in KubernetesConfigModel

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit
 github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
+github.com/hashicorp/terraform v1.8.5 h1:qsZZLERVJoBe7a9PlVaZAmi+18qsBnbSSbrtAlsBoIY=
+github.com/hashicorp/terraform v1.8.5/go.mod h1:OC3k+XdVxkJoH11DNifOaxrqNQUxBneFcCAUxiqW0U0=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=
 github.com/hashicorp/terraform-exec v0.21.0/go.mod h1:1PPeMYou+KDUSSeRE9szMZ/oHf4fYUmB923Wzbq1ICg=
 github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7orfb5Ltvec=

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,6 @@ github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit
 github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform v1.8.5 h1:qsZZLERVJoBe7a9PlVaZAmi+18qsBnbSSbrtAlsBoIY=
-github.com/hashicorp/terraform v1.8.5/go.mod h1:OC3k+XdVxkJoH11DNifOaxrqNQUxBneFcCAUxiqW0U0=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=
 github.com/hashicorp/terraform-exec v0.21.0/go.mod h1:1PPeMYou+KDUSSeRE9szMZ/oHf4fYUmB923Wzbq1ICg=
 github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7orfb5Ltvec=

--- a/helm-framework/helm/kubeConfig.go
+++ b/helm-framework/helm/kubeConfig.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/mitchellh/go-homedir"
@@ -80,16 +81,12 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		return nil, fmt.Errorf("configuration error: missing required structural data")
 	}
 
-	// Extract the first element from the Kubernetes list
+	// Get the Kubernetes configuration as an object
 	var kubernetesConfig KubernetesConfigModel
-	var kubernetesConfigs []KubernetesConfigModel
-	// TODO look into this next
-	diags := m.Data.Kubernetes.ElementsAs(ctx, &kubernetesConfigs, true)
+	diags := m.Data.Kubernetes.As(ctx, &kubernetesConfig, basetypes.ObjectAsOptions{})
 	if diags.HasError() {
-		return nil, fmt.Errorf("configuration error: unable to extract Kubernetes config %#v", diags[0])
-	}
-	if len(kubernetesConfigs) > 0 {
-		kubernetesConfig = kubernetesConfigs[0]
+		fmt.Println("Error extracting Kubernetes config", diags[0])
+		return nil, fmt.Errorf("configuration error: unable to extract Kubernetes config")
 	}
 
 	// Check ConfigPath
@@ -108,10 +105,8 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		configPaths = filepath.SplitList(v)
 	}
 	tflog.Debug(ctx, "Initial configPaths", map[string]interface{}{"configPaths": configPaths})
+
 	if len(configPaths) > 0 {
-		tflog.Debug(ctx, "Processing config paths", map[string]interface{}{
-			"configPaths": configPaths,
-		})
 		expandedPaths := []string{}
 		for _, p := range configPaths {
 			path, err := homedir.Expand(p)
@@ -122,9 +117,6 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 				})
 				return nil, err
 			}
-			tflog.Debug(ctx, "Using kubeconfig", map[string]interface{}{
-				"path": path,
-			})
 			expandedPaths = append(expandedPaths, path)
 		}
 		if len(expandedPaths) == 1 {
@@ -132,51 +124,31 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		} else {
 			loader.Precedence = expandedPaths
 		}
-		tflog.Debug(ctx, "Debug - loader struct2", map[string]interface{}{
-			"loader": loader,
-		})
 
 		// Check ConfigContext
 		if !kubernetesConfig.ConfigContext.IsNull() {
 			overrides.CurrentContext = kubernetesConfig.ConfigContext.ValueString()
-			tflog.Debug(ctx, "Setting config context", map[string]interface{}{
-				"configContext": overrides.CurrentContext,
-			})
 		}
 		if !kubernetesConfig.ConfigContextAuthInfo.IsNull() {
 			overrides.Context.AuthInfo = kubernetesConfig.ConfigContextAuthInfo.ValueString()
-			tflog.Debug(ctx, "Setting config context auth info", map[string]interface{}{
-				"configContextAuthInfo": overrides.Context.AuthInfo,
-			})
 		}
 		if !kubernetesConfig.ConfigContextCluster.IsNull() {
 			overrides.Context.Cluster = kubernetesConfig.ConfigContextCluster.ValueString()
-			tflog.Debug(ctx, "Setting config context cluster", map[string]interface{}{
-				"configContextCluster": overrides.Context.Cluster,
-			})
 		}
 	}
 
 	// Check and assign remaining fields
 	if !kubernetesConfig.Insecure.IsNull() {
 		overrides.ClusterInfo.InsecureSkipTLSVerify = kubernetesConfig.Insecure.ValueBool()
-		tflog.Debug(ctx, "Setting insecure skip TLS verify", map[string]interface{}{
-			"insecureSkipTLSVerify": overrides.ClusterInfo.InsecureSkipTLSVerify,
-		})
 	}
 	if !kubernetesConfig.TLSServerName.IsNull() {
 		overrides.ClusterInfo.TLSServerName = kubernetesConfig.TLSServerName.ValueString()
-		tflog.Debug(ctx, "Setting TLS server name", map[string]interface{}{
-			"tlsServerName": overrides.ClusterInfo.TLSServerName,
-		})
 	}
 	if !kubernetesConfig.ClusterCACertificate.IsNull() {
 		overrides.ClusterInfo.CertificateAuthorityData = []byte(kubernetesConfig.ClusterCACertificate.ValueString())
-		tflog.Debug(ctx, "Setting cluster CA certificate")
 	}
 	if !kubernetesConfig.ClientCertificate.IsNull() {
 		overrides.AuthInfo.ClientCertificateData = []byte(kubernetesConfig.ClientCertificate.ValueString())
-		tflog.Debug(ctx, "Setting client certificate")
 	}
 	if !kubernetesConfig.Host.IsNull() && kubernetesConfig.Host.ValueString() != "" {
 		hasCA := len(overrides.ClusterInfo.CertificateAuthorityData) != 0
@@ -184,43 +156,25 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		defaultTLS := hasCA || hasCert || overrides.ClusterInfo.InsecureSkipTLSVerify
 		host, _, err := rest.DefaultServerURL(kubernetesConfig.Host.ValueString(), "", schema.GroupVersion{}, defaultTLS)
 		if err != nil {
-			tflog.Error(ctx, "Error setting host", map[string]interface{}{
-				"host":  kubernetesConfig.Host.ValueString(),
-				"error": err,
-			})
 			return nil, err
 		}
 		overrides.ClusterInfo.Server = host.String()
-		tflog.Debug(ctx, "Setting host", map[string]interface{}{
-			"host": overrides.ClusterInfo.Server,
-		})
 	}
 
 	if !kubernetesConfig.Username.IsNull() {
 		overrides.AuthInfo.Username = kubernetesConfig.Username.ValueString()
-		tflog.Debug(ctx, "Setting username", map[string]interface{}{
-			"username": overrides.AuthInfo.Username,
-		})
 	}
 	if !kubernetesConfig.Password.IsNull() {
 		overrides.AuthInfo.Password = kubernetesConfig.Password.ValueString()
-		tflog.Debug(ctx, "Setting password")
 	}
 	if !kubernetesConfig.ClientKey.IsNull() {
 		overrides.AuthInfo.ClientKeyData = []byte(kubernetesConfig.ClientKey.ValueString())
-		tflog.Debug(ctx, "Setting client key")
 	}
 	if !kubernetesConfig.Token.IsNull() {
 		overrides.AuthInfo.Token = kubernetesConfig.Token.ValueString()
-		tflog.Debug(ctx, "Setting token", map[string]interface{}{
-			"token": overrides.AuthInfo.Token,
-		})
 	}
 	if !kubernetesConfig.ProxyURL.IsNull() {
 		overrides.ClusterDefaults.ProxyURL = kubernetesConfig.ProxyURL.ValueString()
-		tflog.Debug(ctx, "Setting proxy URL", map[string]interface{}{
-			"proxyURL": overrides.ClusterDefaults.ProxyURL,
-		})
 	}
 
 	execConfig := kubernetesConfig.Exec
@@ -237,28 +191,17 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 			exec.Env = append(exec.Env, clientcmdapi.ExecEnvVar{Name: k, Value: v.(types.String).ValueString()})
 		}
 		overrides.AuthInfo.Exec = exec
-		tflog.Debug(ctx, "Setting exec configuration", map[string]interface{}{
-			"execConfig": exec,
-		})
 	}
 	overrides.Context.Namespace = "default"
 	if namespace != "" {
 		overrides.Context.Namespace = namespace
-		tflog.Debug(ctx, "Setting namespace", map[string]interface{}{
-			"namespace": overrides.Context.Namespace,
-		})
 	}
 
-	// Creating the k8s client config, using the loaded and overrides.
 	burstLimit := int(m.Data.BurstLimit.ValueInt64())
 	client := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides)
 	if client == nil {
-		tflog.Error(ctx, "Failed to initialize kubernetes config")
 		return nil, fmt.Errorf("failed to initialize kubernetes config")
 	}
-	tflog.Info(ctx, "Successfully initialized kubernetes config")
-	fmt.Printf("ClientConfig: %+v\n", client)
-	fmt.Printf("BurstLimit: %d\n", burstLimit)
 	return &KubeConfig{ClientConfig: client, Burst: burstLimit}, nil
 }
 

--- a/helm-framework/helm/provider.go
+++ b/helm-framework/helm/provider.go
@@ -76,22 +76,22 @@ type RegistryConfigModel struct {
 
 // KubernetesConfigModel configures a Kubernetes client
 type KubernetesConfigModel struct {
-	Host                  types.String `tfsdk:"host"`
-	Username              types.String `tfsdk:"username"`
-	Password              types.String `tfsdk:"password"`
-	Insecure              types.Bool   `tfsdk:"insecure"`
-	TLSServerName         types.String `tfsdk:"tls_server_name"`
-	ClientCertificate     types.String `tfsdk:"client_certificate"`
-	ClientKey             types.String `tfsdk:"client_key"`
-	ClusterCACertificate  types.String `tfsdk:"cluster_ca_certificate"`
-	ConfigPaths           types.List   `tfsdk:"config_paths"`
-	ConfigPath            types.String `tfsdk:"config_path"`
-	ConfigContext         types.String `tfsdk:"config_context"`
-	ConfigContextAuthInfo types.String `tfsdk:"config_context_auth_info"`
-	ConfigContextCluster  types.String `tfsdk:"config_context_cluster"`
-	Token                 types.String `tfsdk:"token"`
-	ProxyURL              types.String `tfsdk:"proxy_url"`
-	// Exec                  types.List   `tfsdk:"exec"`
+	Host                  types.String    `tfsdk:"host"`
+	Username              types.String    `tfsdk:"username"`
+	Password              types.String    `tfsdk:"password"`
+	Insecure              types.Bool      `tfsdk:"insecure"`
+	TLSServerName         types.String    `tfsdk:"tls_server_name"`
+	ClientCertificate     types.String    `tfsdk:"client_certificate"`
+	ClientKey             types.String    `tfsdk:"client_key"`
+	ClusterCACertificate  types.String    `tfsdk:"cluster_ca_certificate"`
+	ConfigPaths           types.List      `tfsdk:"config_paths"`
+	ConfigPath            types.String    `tfsdk:"config_path"`
+	ConfigContext         types.String    `tfsdk:"config_context"`
+	ConfigContextAuthInfo types.String    `tfsdk:"config_context_auth_info"`
+	ConfigContextCluster  types.String    `tfsdk:"config_context_cluster"`
+	Token                 types.String    `tfsdk:"token"`
+	ProxyURL              types.String    `tfsdk:"proxy_url"`
+	Exec                  ExecConfigModel `tfsdk:"exec"`
 }
 
 // ExecConfigModel configures an external command to configure the Kubernetes client
@@ -274,16 +274,11 @@ func kubernetesResourceSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "URL to the proxy to be used for all API requests.",
 		},
-		//  "exec": schema.ListNestedAttribute{
-		//  	Optional: true,
-		//  	Validators: []validator.List{
-		//  		listvalidator.SizeAtMost(1),
-		//  	},
-		//  	Description: "Exec configuration for Kubernetes authentication",
-		//  	NestedObject: schema.NestedAttributeObject{
-		//  		Attributes: execSchema(),
-		//  	},
-		//  },
+		"exec": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "Exec configuration for Kubernetes authentication",
+			Attributes:  execSchema(),
+		},
 	}
 }
 

--- a/helm-framework/helm/provider.go
+++ b/helm-framework/helm/provider.go
@@ -244,10 +244,11 @@ func kubernetesResourceSchema() map[string]schema.Attribute {
 			Description: "Path to the kube config file. Can be set with KUBE_CONFIG_PATH.",
 			Validators: []validator.String{
 				stringvalidator.ConflictsWith(
-					path.Root("kubernetes").AtListIndex(0).AtName("config_paths").Expression(),
+					path.Root("kubernetes").AtName("config_paths").Expression(),
 				),
 			},
 		},
+
 		"config_context": schema.StringAttribute{
 			Optional:    true,
 			Description: "Context to choose from the config file. Can be sourced from KUBE_CTX.",

--- a/helm-framework/helm/provider.go
+++ b/helm-framework/helm/provider.go
@@ -298,6 +298,14 @@ func execSchema() map[string]schema.Attribute {
 		},
 	}
 }
+func execSchemaAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"api_version": types.StringType,
+		"command":     types.StringType,
+		"args":        types.ListType{ElemType: types.StringType},
+		"env":         types.MapType{ElemType: types.StringType},
+	}
+}
 
 /////////////////////     					END OF SCHEMA CREATION           ///////////////////////////////
 
@@ -503,6 +511,7 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		"config_context_cluster":   types.StringType,
 		"token":                    types.StringType,
 		"proxy_url":                types.StringType,
+		"exec":                     types.ObjectType{AttrTypes: execSchemaAttrTypes()},
 	}, map[string]attr.Value{
 		"host":                     types.StringValue(kubeHost),
 		"username":                 types.StringValue(kubeUser),
@@ -519,6 +528,12 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		"config_context_cluster":   types.StringValue(kubeConfigContextCluster),
 		"token":                    types.StringValue(kubeToken),
 		"proxy_url":                types.StringValue(kubeProxy),
+		"exec": types.ObjectValueMust(execSchemaAttrTypes(), map[string]attr.Value{
+			"api_version": types.StringValue(kubernetesConfig.Exec.APIVersion.ValueString()),
+			"command":     types.StringValue(kubernetesConfig.Exec.Command.ValueString()),
+			"args":        types.ListValueMust(types.StringType, kubernetesConfig.Exec.Args.Elements()),
+			"env":         types.MapValueMust(types.StringType, kubernetesConfig.Exec.Env.Elements()),
+		}),
 	})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/helm-framework/helm/resource_helm_release_test.go
+++ b/helm-framework/helm/resource_helm_release_test.go
@@ -1825,9 +1825,9 @@ func TestAccResourceRelease_OCI_registry_login(t *testing.T) {
 func testAccHelmReleaseConfig_OCI_login_provider(kubeconfig, resource, ns, name, repo, version, username, password, chart string) string {
 	return fmt.Sprintf(`
 provider "helm" {
-    kubernetes = [{
+    kubernetes = {
         config_path = "%s"
-    }]
+    }
     registries = [{
         url      = "%s"
         username = "%s"


### PR DESCRIPTION

### Description

This PR refactors the `exec` and `kubernetes` block in the `KubernetesConfigModel` from a `ListNestedAttribute` to a `SingleNestedAttribute`. The `exec` block was previously defined as a list, allowing multiple configurations, but the actual use case only requires one configuration.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
