### PR TITLE
Fix nil pointer deref panic on helm_release destroy

### DIFF
--- a/.changelog/1501.txt
+++ b/.changelog/1501.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: Fix nil pointer deref panic on destroy when helm release is not found
+```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -869,7 +869,7 @@ func resourceReleaseDelete(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	if res.Info != "" {
+	if res != nil && res.Info != "" {
 		return diag.Diagnostics{
 			{
 				Severity: diag.Warning,


### PR DESCRIPTION
### Description

Fix nil pointer deref panic in `helm_resource` introduced in `2.16.0` through GH-1487. This occurs, when the to-be-destroyed resource no more exists in K8s and helm returns "release not found" as the response is nil in this case.

Fixes https://github.com/hashicorp/terraform-provider-helm/issues/1500

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix helm_resource destroy panic when helm chart release is not found
```
### References

- https://github.com/hashicorp/terraform-provider-helm/issues/1500
- https://github.com/hashicorp/terraform-provider-helm/pull/1487

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
