### PR TITLE
FIX(#1158): add support for helm literal values

### DIFF
--- a/helm/data_template.go
+++ b/helm/data_template.go
@@ -124,7 +124,7 @@ func dataTemplate() *schema.Resource {
 							// TODO: use ValidateDiagFunc once an SDK v2 version of StringInSlice exists.
 							// https://github.com/hashicorp/terraform-plugin-sdk/issues/534
 							ValidateFunc: validation.StringInSlice([]string{
-								"auto", "string",
+								"auto", "string", "literal",
 							}, false),
 						},
 					},
@@ -167,7 +167,7 @@ func dataTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								"auto", "string",
+								"auto", "string", "literal",
 							}, false),
 						},
 					},

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -161,7 +161,7 @@ func resourceRelease() *schema.Resource {
 							// TODO: use ValidateDiagFunc once an SDK v2 version of StringInSlice exists.
 							// https://github.com/hashicorp/terraform-plugin-sdk/issues/534
 							ValidateFunc: validation.StringInSlice([]string{
-								"auto", "string",
+								"auto", "string", "literal",
 							}, false),
 						},
 					},
@@ -204,7 +204,7 @@ func resourceRelease() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								"auto", "string",
+								"auto", "string", "literal",
 							}, false),
 						},
 					},
@@ -1392,6 +1392,10 @@ func getValue(base, set map[string]interface{}) error {
 		}
 	case "string":
 		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
+			return fmt.Errorf("failed parsing key %q with value %s, %s", name, value, err)
+		}
+	case "literal":
+		if err := strvals.ParseLiteralInto(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			return fmt.Errorf("failed parsing key %q with value %s, %s", name, value, err)
 		}
 	default:

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -1266,6 +1266,27 @@ func TestGetValuesString(t *testing.T) {
 	}
 }
 
+func TestGetValuesLiteral(t *testing.T) {
+	d := resourceRelease().Data(nil)
+	err := d.Set("set", []interface{}{
+		map[string]interface{}{"name": "foo", "value": "{[]_who", "type": "literal"},
+	})
+	if err != nil {
+		t.Fatalf("error setting values: %s", err)
+		return
+	}
+
+	values, err := getValues(d)
+	if err != nil {
+		t.Fatalf("error getValues: %s", err)
+		return
+	}
+
+	if values["foo"] != "{[]_who" {
+		t.Fatalf("error merging values, expected %q, got %s", "{[]_who", values["foo"])
+	}
+}
+
 func TestUseChartVersion(t *testing.T) {
 
 	type test struct {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fixes #1158 by adding support for literal helm values.

```hcl
data "helm_template" "test" {
  name      = "test"
  namespace = "test"
  chart     = "./testChart"

  set_sensitive {
    name  = "password"
    type  = "literal"
    value = "{\"'hello_world"
  }
}
```

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add support for helm literal values
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

#1158 
#1474
https://github.com/helm/helm/pull/9182

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
