### PR TITLE
`helm-framework`: refactor `metadata` from `ListNestedAttribute` -> `SingleNestedAttribute`

### DIFF
--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -1458,7 +1458,7 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, r *relea
 	}
 
 	// Convert the list of ObjectValues to a ListValue
-	metadataList, diag := types.ObjectValue(metadataAttrTypes(), metadata)
+	metadataObject, diag := types.ObjectValue(metadataAttrTypes(), metadata)
 	diags.Append(diag...)
 	if diags.HasError() {
 		tflog.Error(ctx, "Error converting metadata to ListValue", map[string]interface{}{
@@ -1470,8 +1470,8 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, r *relea
 	}
 
 	// Log metadata after conversion
-	tflog.Debug(ctx, fmt.Sprintf("Metadata after conversion: %+v", metadataList))
-	state.Metadata = metadataList
+	tflog.Debug(ctx, fmt.Sprintf("Metadata after conversion: %+v", metadataObject))
+	state.Metadata = metadataObject
 	return diags
 }
 
@@ -1657,7 +1657,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 
 	if recomputeMetadata(plan, state) {
 		tflog.Debug(ctx, fmt.Sprintf("%s Metadata has changes, setting to unknown", logID))
-		plan.Metadata = types.ObjectNull(metadataAttrTypes())
+		plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
 	}
 
 	if !useChartVersion(plan.Chart.ValueString(), plan.Repository.ValueString()) {
@@ -1670,7 +1670,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 
 			if oldVersionStr != newVersionStr && newVersionStr != "" {
 				// Setting Metadata to a computed value
-				plan.Metadata = types.ObjectNull(metadataAttrTypes())
+				plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
 			}
 		}
 	}

--- a/helm-framework/helm/resource_helm_release_test.go
+++ b/helm-framework/helm/resource_helm_release_test.go
@@ -39,21 +39,21 @@ func TestAccResourceRelease_basic(t *testing.T) {
 			{
 				Config: testAccHelmReleaseConfigBasic(testResourceName, namespace, name, "1.2.3"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", namespace),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 					resource.TestCheckResourceAttr("helm_release.test", "description", "Test"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.chart", "test-chart"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.app_version", "1.19.5"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.app_version", "1.19.5"),
 				),
 			},
 			{
 				Config: testAccHelmReleaseConfigBasic(testResourceName, namespace, name, "1.2.3"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 					resource.TestCheckResourceAttr("helm_release.test", "description", "Test"),
 				),
@@ -75,13 +75,13 @@ func TestAccResourceRelease_emptyVersion(t *testing.T) {
 			{
 				Config: testAccHelmReleaseConfigEmptyVersion(testResourceName, namespace, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.namespace", namespace),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.name", name),
+					resource.TestCheckResourceAttr(resourceName, "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr(resourceName, "metadata.revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.chart", "test-chart"),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.version", "2.0.0"),
-					resource.TestCheckResourceAttr(resourceName, "metadata.0.app_version", "1.19.5"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.chart", "test-chart"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "2.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.app_version", "1.19.5"),
 				),
 			},
 		},
@@ -103,8 +103,8 @@ func TestAccResourceRelease_import(t *testing.T) {
 			{
 				Config: testAccHelmReleaseConfigBasic(testResourceName, namespace, name, "1.2.3"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 				),
 			},
@@ -116,8 +116,8 @@ func TestAccResourceRelease_import(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"set", "set.#", "repository"},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.imported", "metadata.0.revision", "1"),
-					resource.TestCheckResourceAttr("helm_release.imported", "metadata.0.version", "1.2.0"),
+					resource.TestCheckResourceAttr("helm_release.imported", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.imported", "metadata.version", "1.2.0"),
 					resource.TestCheckResourceAttr("helm_release.imported", "status", release.StatusDeployed.String()),
 					resource.TestCheckResourceAttr("helm_release.imported", "description", "Test"),
 					resource.TestCheckNoResourceAttr("helm_release.imported", "repository"),
@@ -199,7 +199,7 @@ func TestAccResourceRelease_multiple_releases(t *testing.T) {
 				}
 			}`, resourceName, releaseName, namespace, testRepositoryURL, randomKey, randomValue),
 			resource.TestCheckResourceAttr(
-				fmt.Sprintf("helm_release.%s", resourceName), "metadata.0.name", releaseName,
+				fmt.Sprintf("helm_release.%s", resourceName), "metadata.name", releaseName,
 			)
 	}
 	config := ""
@@ -267,8 +267,8 @@ func TestAccResourceRelease_update(t *testing.T) {
 			{
 				Config: testAccHelmReleaseConfigBasic(testResourceName, namespace, name, "1.2.3"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 					resource.TestCheckResourceAttr("helm_release.test", "version", "1.2.3"),
 				),
@@ -276,8 +276,8 @@ func TestAccResourceRelease_update(t *testing.T) {
 			{
 				Config: testAccHelmReleaseConfigBasic(testResourceName, namespace, name, "2.0.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "2.0.0"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "2.0.0"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 					resource.TestCheckResourceAttr("helm_release.test", "version", "2.0.0"),
 				),
@@ -300,9 +300,9 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 					testResourceName, namespace, name, "test-chart", "1.2.3", []string{""},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{}"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", "{}"),
 				),
 			},
 		},
@@ -323,9 +323,9 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 					testResourceName, namespace, name, "test-chart", "1.2.3", []string{"foo: bar"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{\"foo\":\"bar\"}"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", "{\"foo\":\"bar\"}"),
 				),
 			},
 			{
@@ -333,9 +333,9 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 					testResourceName, namespace, name, "test-chart", "1.2.3", []string{"foo: baz"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{\"foo\":\"baz\"}"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", "{\"foo\":\"baz\"}"),
 				),
 			},
 		},
@@ -356,9 +356,9 @@ func TestAccResourceRelease_cloakValues(t *testing.T) {
 					testResourceName, namespace, name, "test-chart", "1.2.3", "foo", "bar",
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values",
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values",
 						"{\"foo\":\"(sensitive value)\"}"),
 				),
 			},
@@ -381,9 +381,9 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 					"test-chart", "1.2.3", []string{"foo: bar"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{\"foo\":\"bar\"}"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", "{\"foo\":\"bar\"}"),
 				),
 			},
 			{
@@ -392,9 +392,9 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 					"test-chart", "1.2.3", []string{"foo: bar", "foo: baz"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{\"foo\":\"baz\"}"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", "{\"foo\":\"baz\"}"),
 				),
 			},
 		},
@@ -412,18 +412,18 @@ func TestAccResourceRelease_repository_url(t *testing.T) {
 			{
 				Config: testAccHelmReleaseConfigRepositoryURL(testResourceName, namespace, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
+					resource.TestCheckResourceAttrSet("helm_release.test", "metadata.version"),
 					resource.TestCheckResourceAttrSet("helm_release.test", "version"),
 				),
 			},
 			{
 				Config: testAccHelmReleaseConfigRepositoryURL(testResourceName, namespace, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
+					resource.TestCheckResourceAttrSet("helm_release.test", "metadata.version"),
 					resource.TestCheckResourceAttrSet("helm_release.test", "version"),
 				),
 			},
@@ -484,8 +484,8 @@ func TestAccResourceRelease_updateAfterFail(t *testing.T) {
 			{
 				Config: fixed,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.chart", "test-chart"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 				),
 			},
@@ -508,7 +508,7 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 					[]string{"serviceAccount:\n  name: valid-name"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 				),
 			},
@@ -520,7 +520,7 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 				ExpectError:        regexp.MustCompile("Unsupported value"),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", "FAILED"),
 				),
 			},


### PR DESCRIPTION
### Description

The tfstate is now in the `SingleNestedAttirbute` format:

```hcl
(base) ┌─(~/Dev/Scratch/helm-framework-scratch)────────────────────────────────────────────────────────(mau@mau-JKDT676NCP:s029)─┐
└─(11:44:11)──> cat terraform.tfstate                                                                   1 ↵ ──(Fri,Oct25)─┘
{
  "version": 4,
  "terraform_version": "1.8.0",
  "serial": 3,
  "lineage": "4224ea60-8c75-7e04-304a-2247f1516dd0",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "helm_release",
      "name": "helm_migration_test_1",
      "provider": "provider[\"registry.terraform.io/hashicorp/helm\"]",
      "instances": [
        {
          "status": "tainted",
          "schema_version": 1,
          "attributes": {
            "atomic": false,
            "chart": "redis",
            "cleanup_on_fail": false,
            "create_namespace": false,
            "dependency_update": false,
            "description": "Test",
            "devel": null,
            "disable_crd_hooks": false,
            "disable_openapi_validation": false,
            "disable_webhooks": false,
            "force_update": false,
            "id": "helm-test-1",
            "keyring": null,
            "lint": false,
            "manifest": null,
            "max_history": 0,
            "metadata": {
              "app_version": "7.4.0",
              "chart": "redis",
              "first_deployed": 1729881734,
              "last_deployed": 1729881734,
              "name": "helm-test-1",
              "namespace": "default",
              "revision": 1,
              "values": "{}",
              "version": "20.1.4"
            },
            "name": "helm-test-1",
            "namespace": "default",
            "pass_credentials": false,
            "postrender": null,
            "recreate_pods": false,
            "render_subchart_notes": true,
            "replace": false,
            "repository": "bitnami",
            "repository_ca_file": null,
            "repository_cert_file": null,
            "repository_key_file": null,
            "repository_password": null,
            "repository_username": null,
            "reset_values": false,
            "reuse_values": false,
            "set": null,
            "set_list": null,
            "set_sensitive": null,
            "skip_crds": false,
            "status": "deployed",
            "timeout": 300,
            "values": null,
            "verify": false,
            "version": "20.1.4",
            "wait": true,
            "wait_for_jobs": false
          },
          "sensitive_attributes": [
            [
              {
                "type": "get_attr",
                "value": "repository_password"
              }
            ]
          ]
        }
      ]
    }
  ],
  "check_results": null
}
```

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
