### PR TITLE
Add custom default for namespace

### DIFF
--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -221,35 +222,26 @@ func suppressKeyring() planmodifier.String {
 	return suppressKeyringPlanModifier{}
 }
 
-type NamespacePlanModifier struct{}
-
-func (m NamespacePlanModifier) Description(context.Context) string {
-	return "Sets the namespace value from the HELM_NAMESPACE environment variable or defaults to 'default'."
+func namespaceDefault() defaults.String {
+	return namespaceDefaultValue{}
 }
 
-func (m NamespacePlanModifier) MarkdownDescription(ctx context.Context) string {
-	return m.Description(ctx)
+type namespaceDefaultValue struct{}
+
+func (d namespaceDefaultValue) Description(ctx context.Context) string {
+	return "If namespace is not provided, defaults to HELM_NAMESPACE environment variable or 'default'."
 }
 
-func (m NamespacePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	var namespace types.String
-	diags := req.Plan.GetAttribute(ctx, path.Root("namespace"), &namespace)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
+func (d namespaceDefaultValue) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d namespaceDefaultValue) DefaultString(ctx context.Context, req defaults.StringRequest, resp *defaults.StringResponse) {
+	envNamespace := os.Getenv("HELM_NAMESPACE")
+	if envNamespace == "" {
+		envNamespace = "default"
 	}
-
-	if namespace.IsNull() || namespace.ValueString() == "" {
-		envNamespace := os.Getenv("HELM_NAMESPACE")
-		if envNamespace == "" {
-			envNamespace = "default"
-		}
-		resp.PlanValue = types.StringValue(envNamespace)
-	}
-}
-
-func NewNamespacePlanModifier() planmodifier.String {
-	return &NamespacePlanModifier{}
+	resp.PlanValue = types.StringValue(envNamespace)
 }
 
 func (r *HelmRelease) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -407,12 +399,13 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"namespace": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				Default:  namespaceDefault(),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
-					NewNamespacePlanModifier(),
 				},
 				Description: "Namespace to install the release into",
 			},
+
 			"pass_credentials": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Pass credentials to all domains",


### PR DESCRIPTION
### Description

This PR introduces a custom default value for the namespace attribute in the HelmRelease resource. The default is set to use the HELM_NAMESPACE environment variable, or fall back to "default" if the variable is not defined.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
