### PR TITLE
Adding documentation strings for the config_context fields

### DIFF
--- a/helm-framework/helm/provider.go
+++ b/helm-framework/helm/provider.go
@@ -256,16 +256,15 @@ func kubernetesResourceSchema() map[string]schema.Attribute {
 		},
 		"config_context": schema.StringAttribute{
 			Optional:    true,
-			Description: "Context to use for Kubernetes config.",
+			Description: "Context to choose from the config file. Can be sourced from KUBE_CTX.",
 		},
 		"config_context_auth_info": schema.StringAttribute{
-			Optional: true,
-			// TODO REFERENCE THE DEFAULT DOCUMENTATI
-			Description: "AuthInfo to use for Kubernetes config context.",
+			Optional:    true,
+			Description: "Authentication info context of the kube config (name of the kubeconfig user, --user flag in kubectl). Can be sourced from KUBE_CTX_AUTH_INFO.",
 		},
 		"config_context_cluster": schema.StringAttribute{
 			Optional:    true,
-			Description: "Cluster to use for Kubernetes config context.",
+			Description: "Cluster context of the kube config (name of the kubeconfig cluster, --cluster flag in kubectl). Can be sourced from KUBE_CTX_CLUSTER.",
 		},
 		"token": schema.StringAttribute{
 			Optional:    true,


### PR DESCRIPTION
### Description

This pr adds Documentation strings for the `config_context` fields
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
