### PR TITLE
Removing marshaling and unmarshaling and replacing with maps.clone

### DIFF
--- a/helm-framework/helm/resource_helm_release.go
+++ b/helm-framework/helm/resource_helm_release.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
 	pathpkg "path"
@@ -1327,20 +1328,8 @@ func getValue(base map[string]interface{}, set setResourceModel) diag.Diagnostic
 
 func logValues(ctx context.Context, values map[string]interface{}, state *HelmReleaseModel) diag.Diagnostics {
 	var diags diag.Diagnostics
-
-	// Copy array to avoid changing values by the cloak function.
-	asJSON, err := json.Marshal(values)
-	if err != nil {
-		diags.AddError("Error marshaling values to JSON", fmt.Sprintf("Failed to marshal values to JSON: %s", err))
-		return diags
-	}
-
-	var c map[string]interface{}
-	err = json.Unmarshal(asJSON, &c)
-	if err != nil {
-		diags.AddError("Error unmarshaling JSON to map", fmt.Sprintf("Failed to unmarshal JSON to map: %s", err))
-		return diags
-	}
+	//Cloning values map
+	c := maps.Clone(values)
 
 	cloakSetValues(c, state)
 


### PR DESCRIPTION
### Description

This pr removes marshalling and unmarshalling a json to a map in the `logValues` function, and is now using` maps.clone`.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
