### PR TITLE
Update max_history default value to 10

### DIFF
--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -34,7 +34,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `force_update` (Boolean) Force resource update through delete/recreate if needed. Defaults to `false`.
 - `keyring` (String) Location of public keys used for verification. Used only if `verify` is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home`.
 - `lint` (Boolean) Run helm lint when planning. Defaults to `false`.
-- `max_history` (Number) Limit the maximum number of revisions saved per release. Use 0 for no limit. Defaults to 0 (no limit).
+- `max_history` (Number) Limit the maximum number of revisions saved per release. Use 0 for no limit. Defaults to 10.
 - `namespace` (String) Namespace to install the release into. Defaults to `default`.
 - `pass_credentials` (Boolean) Pass credentials to all domains. Defaults to `false`.
 - `postrender` (Block List, Max: 1) Postrender command configuration. (see [below for nested schema](#nestedblock--postrender))

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -49,7 +49,7 @@ var defaultAttributes = map[string]interface{}{
 	"reset_values":               false,
 	"reuse_values":               false,
 	"recreate_pods":              false,
-	"max_history":                0,
+	"max_history":                10,
 	"skip_crds":                  false,
 	"cleanup_on_fail":            false,
 	"dependency_update":          false,

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -311,7 +311,7 @@ func TestAccResourceRelease_import(t *testing.T) {
 					resource.TestCheckResourceAttr("helm_release.imported", "reset_values", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "reuse_values", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "recreate_pods", "false"),
-					resource.TestCheckResourceAttr("helm_release.imported", "max_history", "0"),
+					resource.TestCheckResourceAttr("helm_release.imported", "max_history", "10"),
 					resource.TestCheckResourceAttr("helm_release.imported", "skip_crds", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "cleanup_on_fail", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "dependency_update", "false"),


### PR DESCRIPTION
### Description

Update the default value for max_history to 10 align with Helm upgrade https://helm.sh/docs/helm/helm_upgrade/

> --history-max int                            limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)

The default expected behavior we have from Helm is that we have 10 revisions as the default limit. Keeping it at 0 would unintentionally create too many secrets for the revisions. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added? (updated)


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
