### PR TITLE
Removing an attribute that is not defined in the schema from HelmTemplateModel struct

### DIFF
--- a/helm-framework/helm/data_source_helm_template.go
+++ b/helm-framework/helm/data_source_helm_template.go
@@ -81,7 +81,6 @@ type HelmTemplateModel struct {
 	Set                      types.Set    `tfsdk:"set"`
 	SetList                  types.List   `tfsdk:"set_list"`
 	SetSensitive             types.Set    `tfsdk:"set_sensitive"`
-	SetString                types.Set    `tfsdk:"set_string"`
 	ShowOnly                 types.List   `tfsdk:"show_only"`
 	SkipCrds                 types.Bool   `tfsdk:"skip_crds"`
 	SkipTests                types.Bool   `tfsdk:"skip_tests"`
@@ -113,12 +112,6 @@ type SetSensitiveValue struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
-
-type SetStringValue struct {
-	Name  types.String `tfsdk:"name"`
-	Value types.String `tfsdk:"value"`
-}
-
 type Postrender struct {
 	BinaryPath types.String `tfsdk:"binary_path"`
 }


### PR DESCRIPTION
This pr removes the attr `set_string` from the `HelmTemplateModel` struct. The argument is depreciated, and caused a ValueConversion error in several data template tests! 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
