### PR TITLE
🐛 Fix missed postrender binary path arguments parsing

### DIFF
--- a/.changelog/1534.txt
+++ b/.changelog/1534.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resourehelm_release`: fix an issue where `postrender.args` is not parsed correctly.
+```

--- a/.changelog/1534.txt
+++ b/.changelog/1534.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resourehelm_release`: fix an issue where `postrender.args` is not parsed correctly.
+`resoure/helm_release`: fix an issue where `postrender.args` is not parsed correctly.
 ```

--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -665,7 +665,16 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 		upgradeClient.Description = d.Get("description").(string)
 
 		if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-			pr, err := postrender.NewExec(cmd)
+			av := d.Get("postrender.0.args")
+			var args []string
+			for _, arg := range av.([]interface{}) {
+				if arg == nil {
+					continue
+				}
+				args = append(args, arg.(string))
+			}
+
+			pr, err := postrender.NewExec(cmd, args...)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -699,7 +708,16 @@ func resourceReleaseCreate(ctx context.Context, d *schema.ResourceData, meta int
 		instClient.CreateNamespace = d.Get("create_namespace").(bool)
 
 		if cmd := d.Get("postrender.0.binary_path").(string); cmd != "" {
-			pr, err := postrender.NewExec(cmd)
+			av := d.Get("postrender.0.args")
+			var args []string
+			for _, arg := range av.([]interface{}) {
+				if arg == nil {
+					continue
+				}
+				args = append(args, arg.(string))
+			}
+
+			pr, err := postrender.NewExec(cmd, args...)
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -861,15 +861,21 @@ func TestAccResourceRelease_postrender(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccHelmReleaseConfigPostrender(testResourceName, namespace, testResourceName, "echo", "this will not work!", "Wrong", "Code"),
+				Config:      testAccHelmReleaseConfigPostrender(testResourceName, namespace, testResourceName, "echo", "invalid arguments"),
 				ExpectError: regexp.MustCompile("error validating data"),
 			},
 			{
-				Config:      testAccHelmReleaseConfigPostrender(testResourceName, namespace, testResourceName, "foobardoesnotexist"),
+				Config:      testAccHelmReleaseConfigPostrender(testResourceName, namespace, testResourceName, "binNotFound", ""),
 				ExpectError: regexp.MustCompile("unable to find binary"),
 			},
 			{
 				Config: testAccHelmReleaseConfigPostrender(testResourceName, namespace, testResourceName, "true", "Hello", "World", "!"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+				),
+			},
+			{
+				Config: testAccHelmReleaseConfigPostrender(testResourceName, namespace, testResourceName, "testdata/postrender.sh", "this", "that"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 				),
@@ -1534,7 +1540,7 @@ func testAccHelmReleaseConfigPostrender(resource, ns, name, binaryPath string, a
 				value = 1337
 			}
 		}
-	`, resource, name, ns, testRepositoryURL, binaryPath, fmt.Sprintf(`["%s"]`, strings.Join(args, `","`)))
+		`, resource, name, ns, testRepositoryURL, binaryPath, fmt.Sprintf(`["%s"]`, strings.Join(args, `","`)))
 }
 
 func TestAccResourceRelease_LintFailValues(t *testing.T) {

--- a/helm/testdata/postrender.sh
+++ b/helm/testdata/postrender.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: $0 <arg1> <arg2>" >&2
+  exit 1
+fi


### PR DESCRIPTION
### Description

This is a quick fix to the issue where the `postrender.args` attribute is not parsed during creation. It was accidentally removed in this [PR](https://github.com/hashicorp/terraform-provider-helm/pull/1247).

### References

Fix: https://github.com/hashicorp/terraform-provider-helm/issues/1533

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
