### PR TITLE
Recover lost clarification

### DIFF
--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -64,7 +64,7 @@ For further details on the `helm template` command, refer to the [Helm documenta
 - `validate` (Boolean) Validate your manifests against the Kubernetes cluster you are currently pointing at. This is the same validation performed on an install
 - `values` (List of String) List of values in raw yaml format to pass to helm.
 - `verify` (Boolean) Verify the package before installing it.Defaults to `false`.
-- `version` (String) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+- `version` (String) Specify the exact chart version to install. If this is not specified, the latest version is installed. `helm_release` will not automatically grab the latest release, version must explicitly upgraded when upgrading an installed chart.
 - `wait` (Boolean) Will wait until all resources are in a ready state before marking the release as successful.Defaults to `true`.
 
 ### Read-Only

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -57,7 +57,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `upgrade_install` (Boolean) If true, the provider will install the release at the specified version even if a release not controlled by the provider is present: this is equivalent to running 'helm upgrade --install' with the Helm CLI. WARNING: this may not be suitable for production use -- see the 'Upgrade Mode' note in the provider documentation. Defaults to `false`.
 - `values` (List of String) List of values in raw yaml format to pass to helm.
 - `verify` (Boolean) Verify the package before installing it.Defaults to `false`.
-- `version` (String) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+- `version` (String) Specify the exact chart version to install. If this is not specified, the latest version is installed. `helm_release` will not automatically grab the latest release, version must explicitly upgraded when upgrading an installed chart.
 - `wait` (Boolean) Will wait until all resources are in a ready state before marking the release as successful. Defaults to `true`.
 - `wait_for_jobs` (Boolean) If wait is enabled, will wait until all Jobs have been completed before marking the release as successful. Defaults to `false``.
 


### PR DESCRIPTION
### Description

The current documentation on `version` property is very confusing. I ran into the same issue described in https://github.com/hashicorp/terraform-provider-helm/issues/924 and got very frustrated.

Apparently, the issue _WAS_ fixed in https://github.com/hashicorp/terraform-provider-helm/pull/927 but somehow got lost for whatever reason. This PR simply adds it back to prevent more people from getting confused.


### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
