### PR TITLE
`set.value`: `required` -> `optional`

### DIFF
--- a/.changelog/1572.txt
+++ b/.changelog/1572.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+change `set.value` && `set_list.value` to optional instead of required
+```

--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -85,11 +85,11 @@ Required:
 Required:
 
 - `name` (String)
-- `value` (String)
 
 Optional:
 
 - `type` (String)
+- `value` (String)
 
 
 <a id="nestedblock--set_list"></a>

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -288,7 +288,7 @@ resource "helm_release" "example" {
 The `set`, `set_list`, and `set_sensitive` blocks support:
 
 * `name` - (Required) full name of the variable to be set.
-* `value` - (Required) value of the variable to be set.
+* `value` - (Required; Optional for `set`) value of the variable to be set.
 * `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
 
 Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to escape the `{}`, `[]`, `.`, and `,` characters twice in order for it to be parsed. `name` should also be set to the `value path`, and `value` is the desired value that will be set.

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -86,12 +86,11 @@ Optional:
 Required:
 
 - `name` (String)
-- `value` (String)
 
 Optional:
 
 - `type` (String)
-
+- `value` (String)
 
 <a id="nestedblock--set_list"></a>
 ### Nested Schema for `set_list`

--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -293,7 +293,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 							Required: true,
 						},
 						"value": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 						},
 						"type": schema.StringAttribute{
 							Optional: true,
@@ -311,7 +311,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 						},
 						"value": schema.ListAttribute{
 							Required:    true,

--- a/helm/data_helm_template_test.go
+++ b/helm/data_helm_template_test.go
@@ -235,6 +235,24 @@ func TestAccDataTemplate_kubeVersion(t *testing.T) {
 	})
 }
 
+func TestAccDataTemplate_configSetNull(t *testing.T) {
+	name := randName("basic")
+	namespace := randName(testNamespacePrefix)
+
+	datasourceAddress := fmt.Sprintf("data.helm_template.%s", testResourceName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testAccDataHelmTemplateConfigNullSet(testResourceName, namespace, name, "1.2.3"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				checkResourceAttrNotSet(datasourceAddress, "set.0.value"),
+				checkResourceAttrNotSet(datasourceAddress, "set.1.value"),
+			),
+		}},
+	})
+}
+
 func testAccDataHelmTemplateConfigBasic(resource, ns, name, version string) string {
 	return fmt.Sprintf(`
 		data "helm_template" "%s" {
@@ -279,6 +297,34 @@ func testAccDataHelmTemplateConfigTemplates(resource, ns, name, version string) 
 				{
 					name  = "fizz"
 					value = 1337
+				}
+			]
+
+			show_only = [
+				"templates/configmaps.yaml",
+				""
+			]
+		}
+	`, resource, name, ns, testRepositoryURL, version)
+}
+
+func testAccDataHelmTemplateConfigNullSet(resource, ns, name, version string) string {
+	return fmt.Sprintf(`
+		data "helm_template" "%s" {
+ 			name        = %q
+			namespace   = %q
+			description = "Test"
+			repository  = %q
+  			chart       = "test-chart"
+			version     = %q
+
+			set = [
+				{
+					name  = "foo"
+				},
+				{
+					name  = "fizz"
+					value = null
 				}
 			]
 

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -540,7 +540,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Required: true,
 						},
 						"value": schema.ListAttribute{
-							Optional:    true,
+							Required:    true,
 							ElementType: types.StringType,
 						},
 					},

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -518,7 +518,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Required: true,
 						},
 						"value": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 						},
 						"type": schema.StringAttribute{
 							Optional: true,
@@ -540,7 +540,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Required: true,
 						},
 						"value": schema.ListAttribute{
-							Required:    true,
+							Optional:    true,
 							ElementType: types.StringType,
 						},
 					},


### PR DESCRIPTION
### Description

Fixes #1570 

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

```hcl
󰀵 mau  …/terraform-provider-helm   set-value-optional $!?   v1.23.4   21:01  
 TESTARGS="-run TestAccResourceRelease_SetNull" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./helm" -v -run TestAccResourceRelease_SetNull -timeout 10m
2025/01/24 21:01:54 Created repository package for "broken-chart"
2025/01/24 21:01:54 Created repository package for "crds-chart"
2025/01/24 21:01:54 Created repository package for "dependency-bar"
2025/01/24 21:01:54 Created repository package for "dependency-foo"
2025/01/24 21:01:54 Created repository package for "failed-deploy"
2025/01/24 21:01:54 Created repository package for "kube-version"
2025/01/24 21:01:54 Created repository package for "test-chart"
2025/01/24 21:01:54 Created repository package for "test-chart-v2"
2025/01/24 21:01:54 Created repository package for "umbrella-chart"
2025/01/24 21:01:54 Built chart repository index
=== RUN   TestAccResourceRelease_SetNull
--- PASS: TestAccResourceRelease_SetNull (7.41s)
PASS
ok      github.com/hashicorp/terraform-provider-helm/helm       8.831s
```

![image](https://github.com/user-attachments/assets/998fcbd8-0101-4f3c-91a1-953cac525604)


We aren't able to have the value be null due to the following error occurring:

![image](https://github.com/user-attachments/assets/4962a070-dd47-4191-b58f-cd1ef90ba662)


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
change `set.value` && `set_list.value` to optional instead of required
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
