### PR TITLE
make helm install with insecure tls

### DIFF
--- a/helm/data_helm_template_test.go
+++ b/helm/data_helm_template_test.go
@@ -235,6 +235,21 @@ func TestAccDataTemplate_kubeVersion(t *testing.T) {
 	})
 }
 
+func TestAccDataTemplate_insecure(t *testing.T) {
+	name := randName("insecure")
+	namespace := randName(testNamespacePrefix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testAccDataHelmTemplateInsecure(testResourceName, namespace, name, "1.2.3"),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(fmt.Sprintf("data.helm_template.%s", testResourceName), "insecure", "true"),
+			),
+		}},
+	})
+}
+
 func testAccDataHelmTemplateConfigBasic(resource, ns, name, version string) string {
 	return fmt.Sprintf(`
 		data "helm_template" "%s" {
@@ -327,6 +342,19 @@ func testAccDataHelmTemplateCRDs(resource, ns, name, version string) string {
   			chart        = "crds-chart"
 			include_crds = true
 			version      = %q
+		}
+	`, resource, name, ns, testRepositoryURL, version)
+}
+
+func testAccDataHelmTemplateInsecure(resource, ns, name, version string) string {
+	return fmt.Sprintf(`
+		data "helm_template" "%s" {
+			name        = %q
+			namespace   = %q
+			repository  = %q
+			chart       = "test-chart"
+			version     = %q
+			insecure    = true
 		}
 	`, resource, name, ns, testRepositoryURL, version)
 }

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -2181,3 +2181,35 @@ func testAccHelmReleaseRecomputeMetadataSet(resource, ns, name string) string {
 		}
 `, resource, name, ns, resource)
 }
+
+func TestAccResourceRelease_insecure(t *testing.T) {
+	name := randName("insecure")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfigInsecure(testResourceName, namespace, name, "1.2.3"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "insecure", "true"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+				),
+			},
+		},
+	})
+}
+
+func testAccHelmReleaseConfigInsecure(resource, ns, name, version string) string {
+	return fmt.Sprintf(`
+        resource "helm_release" "%s" {
+            name        = %q
+            namespace   = %q
+            repository  = %q
+            chart       = "test-chart"
+            version     = %q
+            insecure    = true
+        }
+    `, resource, name, ns, testRepositoryURL, version)
+}


### PR DESCRIPTION
### Description

When we deploy Helm Releases with Terraform, we do not have any option to install with insecure option. Especially this is useful when we want to test the deployments with self hosted registries like Harbor etc./

### Acceptance tests
Yes

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow tls insecure chart deployments
```
### References

https://github.com/hashicorp/terraform-provider-helm/issues/1580

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
