### PR TITLE
Fix logging replacing secrets in values.yaml with `(sensitive value)`

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -996,6 +996,7 @@ func applySetSensitiveValue(base map[string]interface{}, setSensitive SetSensiti
 func LogValuesModel(ctx context.Context, values map[string]interface{}, state *HelmTemplateModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Note: Use json to do a deep clone of the values map so we don't modify the original when cloaking sensitive values
 	asJSON, err := json.Marshal(values)
 	if err != nil {
 		diags.AddError("Error marshaling values to JSON", fmt.Sprintf("Failed to marshal values to JSON: %s", err))


### PR DESCRIPTION
### Description

There is currently a bug in the `logValues` function in `helm/resource_helm_release.go` which causes secrets in nested objects in the values map to get replaced with `(sensitive value)`.

To fix this I duplicated the logging code from `helm/data_helm_template.go` which uses json to do a deep clone of the object before replacing the secrets.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
