### PR TITLE
chore: helm_release do not allow duplicate set values

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1280,8 +1280,8 @@ func getValues(ctx context.Context, model *HelmReleaseModel) (map[string]interfa
 	if !model.Set.IsNull() {
 		tflog.Debug(ctx, "Processing Set attribute")
 		var setList []setResourceModel
-		setDiags := model.Set.ElementsAs(ctx, &setList, false)
-		diags.Append(setDiags...)
+		diags.Append(model.Set.ElementsAs(ctx, &setList, false)...)
+		diags.Append(validateNoDuplicateSetNames(setList)...)
 		if diags.HasError() {
 			return nil, diags
 		}
@@ -2174,4 +2174,28 @@ func valuesUnknown(plan HelmReleaseModel) bool {
 		return true
 	}
 	return false
+}
+
+// validateNoDuplicateSetNames checks for duplicate names in set blocks and returns
+// an error diagnostic if any are found.
+func validateNoDuplicateSetNames(setList []setResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	seenNames := make(map[string]int)
+
+	for i, set := range setList {
+		name := set.Name.ValueString()
+
+		if prevIndex, seen := seenNames[name]; seen {
+			diags.AddError(
+				"Duplicate value name in set",
+				fmt.Sprintf("The name '%s' is specified multiple times in 'set' blocks (at indices %d and %d). "+
+					"Each name should only be specified once.", name, prevIndex, i),
+			)
+			return diags
+		}
+
+		seenNames[name] = i
+	}
+
+	return diags
 }

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -635,6 +635,25 @@ func TestAccResourceRelease_updateSetValue(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_duplicateSetNames(t *testing.T) {
+	name := randName("test-duplicate-set-names")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				// Config with duplicate set names should fail
+				Config: testAccHelmReleaseConfigDuplicateSetNames(
+					testResourceName, namespace, name, "1.2.3",
+				),
+				ExpectError: regexp.MustCompile("Duplicate value name in set"),
+			},
+		},
+	})
+}
+
 func TestAccResourceRelease_validation(t *testing.T) {
 	invalidName := "this-helm-release-name-is-longer-than-53-characters-long"
 	namespace := createRandomNamespace(t)
@@ -1036,6 +1055,34 @@ func testAccHelmReleaseConfigSet(resource, ns, name, version, setValue string) s
 			]
 		}
 	`, resource, name, ns, testRepositoryURL, version, setValue)
+}
+
+func testAccHelmReleaseConfigDuplicateSetNames(resource, ns, name, version string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+			name        = %q
+			namespace   = %q
+			description = "Test"
+			repository  = %q
+			chart       = "test-chart"
+			version     = %q
+
+			set = [
+				{
+					name  = "foo"
+					value = "bar"
+				},
+				{
+					name  = "fizz"
+					value = "buzz"
+				},
+				{
+					name  = "foo"
+					value = "different value"
+				}
+			]
+		}
+	`, resource, name, ns, testRepositoryURL, version)
 }
 
 func testAccHelmReleaseConfigSetNull(resource, ns, name, version string) string {


### PR DESCRIPTION
The Helm provider currently (v.2.17.0 and v3.0.0-pre2) allows multiple `set` blocks with the same name (e.g., two `set` blocks with `name = "defaultSSLPolicy"`) just like Helm. However, with the Terraform provider this creates unpredictable and non-intuitive behavior when configuring Helm releases.

Specifically:
1. When multiple blocks set the same name, the behavior is inconsistent and not aligned with user expectations
2. Users cannot reliably predict which value will be used when the same name appears multiple times
3. The order of blocks in the Terraform code doesn't determine which value takes precedence

This leads to confusing behavior where users might expect later blocks to override earlier ones (as Helm works), but instead, the result is unpredictable from the user's perspective.

For example:
```terraform
resource "helm_release" "example" {
  # ...
  
  set = [
    {
      name  = "defaultSSLPolicy"
      value = "ELBSecurityPolicy-TLS13-1-2-2021-06"
    }

    {
      name  = "defaultSSLPolicy"
      value = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
    }
 
  ]
}
```

In this case, which SSL policy will be used is not deterministic from the user's perspective, making it difficult for users to control their configuration.

## Solution

This PR changes the behavior so it explicitly validate that each name is only used once, providing a clear error message if duplicates are found. 

This makes the behavior more intuitive and explicit, helping users avoid subtle configuration errors.

I'd consider this breaking change, but figured I'd submit it anyway as you're about to release `v3.0.0` of the provider, so this could fit there.