### PR TITLE
add support for literal type in set block

### DIFF
--- a/.changelog/1615.txt
+++ b/.changelog/1615.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add `"literal"` as a supported `type` for the `set` block
+```

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -528,7 +528,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Computed: true,
 							Default:  stringdefault.StaticString(""),
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string"),
+								stringvalidator.OneOf("auto", "string", "literal"),
 							},
 						},
 					},
@@ -595,7 +595,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 						"type": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string"),
+								stringvalidator.OneOf("auto", "string", "literal"),
 							},
 						},
 					},
@@ -1369,6 +1369,18 @@ func getValue(base map[string]interface{}, set setResourceModel) diag.Diagnostic
 		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			diags.AddError("Failed parsing string value", fmt.Sprintf("Failed parsing key %q with value %s: %s", name, value, err))
 			return diags
+		}
+	case "literal":
+		var literal interface{}
+		if err := yaml.Unmarshal([]byte(fmt.Sprintf("%s: %s", name, value)), &literal); err != nil {
+			diags.AddError("Failed parsing literal value", fmt.Sprintf("Key %q with literal value %s: %s", name, value, err))
+			return diags
+		}
+
+		if m, ok := literal.(map[string]interface{}); ok {
+			base[name] = m[name]
+		} else {
+			base[name] = literal
 		}
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type: %s", valueType))

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -1787,6 +1787,28 @@ func TestAccResourceRelease_update_set_list_chart(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_literalSet(t *testing.T) {
+	name := randName("literal-set")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfigSetLiteral(testResourceName, namespace, name, "1.2.3"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", "{\"nested\":{\"a\":true,\"b\":1337}}"),
+				),
+			},
+		},
+	})
+}
+
 func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	dockerPath, err := exec.LookPath("docker")
 	if err != nil {
@@ -2353,4 +2375,24 @@ func testAccHelmReleaseRecomputeMetadataSet(resource, ns, name string) string {
 			filename = "${path.module}/foo.bar"
 		}
 `, resource, name, ns, resource)
+}
+func testAccHelmReleaseConfigSetLiteral(resource, ns, name, version string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+			name        = %q
+			namespace   = %q
+			description = "Test"
+			repository  = %q
+			chart       = "test-chart"
+			version     = %q
+
+			set = [
+				{
+					name  = "nested"
+					value = "{ \"a\": true, \"b\": 1337 }"
+					type  = "literal"
+				}
+			]
+		}
+	`, resource, name, ns, testRepositoryURL, version)
 }

--- a/templates/resources/release.md.tmpl
+++ b/templates/resources/release.md.tmpl
@@ -51,11 +51,11 @@ The provider also supports repositories that are added to the local machine outs
 
 {{tffile "examples/resources/release/example_7.tf"}}
 
-The `set`, `set_list`, and `set_sensitive` blocks support:
+The `set`, and `set_sensitive` blocks support:
 
 * `name` - (Required) full name of the variable to be set.
 * `value` - (Required) value of the variable to be set.
-* `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
+* `type` - (Optional) type of the variable to be set. Valid options are `auto`, `string`, and `literal`.
 
 Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to escape the `{}`, `[]`, `.`, and `,` characters twice in order for it to be parsed. `name` should also be set to the `value path`, and `value` is the desired value that will be set.
 


### PR DESCRIPTION
### Description

This PR introduces support for a new type value in the set block of the helm_release resource: "literal".
 Previously, Helm values set through Terraform defaulted to "auto" or "string" 

Addresses #1158 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
