### PR TITLE
Docu fix: provider syntax

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ provider "helm" {
 You can also configure the host, basic auth credentials, and client certificate authentication explicitly or through environment variables.
 
 ```terraform
-provider "helm" = {
+provider "helm" {
   kubernetes {
     host     = "https://cluster_endpoint:port"
 


### PR DESCRIPTION

### Description
Fix the example provider block for the Credentials config example.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
n/a

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->
NONE

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
no

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
