### PR TITLE
Validate helm_release.name during plan to catch invalid release names in plan time

### DIFF
--- a/.changelog/1622.txt
+++ b/.changelog/1622.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`helm_release`: Include validation of `name` during plan phase to catch invalid Helm release names early
+```

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	pathpkg "path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1665,6 +1666,8 @@ func checkChartDependencies(ctx context.Context, model *HelmReleaseModel, c *cha
 	return false, diags
 }
 
+var helmReleaseNameRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
 func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		// resource is being destroyed
@@ -1674,6 +1677,20 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	if !plan.Name.IsNull() {
+		name := plan.Name.ValueString()
+		if !helmReleaseNameRegexp.MatchString(name) {
+			resp.Diagnostics.AddError(
+				"Invalid Helm Release Name",
+				fmt.Sprintf(
+					"Release name %q is invalid. Must match regex %s and be no longer than 53 characters.",
+					name,
+					helmReleaseNameRegexp.String(),
+				),
+			)
+			return
+		}
 	}
 	var state *HelmReleaseModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1684,7 +1684,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 			resp.Diagnostics.AddError(
 				"Invalid Helm Release Name",
 				fmt.Sprintf(
-					"Release name %q is invalid. Must match regex %s and be no longer than 53 characters.",
+					"Release name %q is invalid. Must match regex %s",
 					name,
 					helmReleaseNameRegexp.String(),
 				),

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -767,33 +767,6 @@ func TestAccResourceRelease_namespaceDoesNotExist(t *testing.T) {
 		},
 	})
 }
-
-func TestAccResourceRelease_invalidName(t *testing.T) {
-	namespace := createRandomNamespace(t)
-	defer deleteNamespace(t, namespace)
-
-	broken := fmt.Sprintf(`
-	resource "helm_release" "test" {
-		name        = "1nva&lidname$"
-		namespace   = %q
-		repository  = %q
-		chart       = "test-chart"
-	}`, namespace, testRepositoryURL)
-
-	resource.Test(t, resource.TestCase{
-		// PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		// CheckDestroy:             testAccCheckHelmReleaseDestroy(namespace),
-		Steps: []resource.TestStep{
-			{
-				Config:             broken,
-				ExpectError:        regexp.MustCompile("invalid release name"),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
 func TestAccResourceRelease_createNamespace(t *testing.T) {
 	name := randName("create-namespace")
 	namespace := randName("helm-created-namespace")

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -823,7 +823,7 @@ func TestAccResourceRelease_createNamespace(t *testing.T) {
 		},
 	})
 }
-func TestAccResourceRelease_invalidReleaseName(t *testing.T) {
+func TestAccResourceRelease_planValidationInvalidName(t *testing.T) {
 	invalidNames := []string{
 		"invalid_helm_release_name",
 		"ThisHelmRelease",
@@ -837,7 +837,7 @@ func TestAccResourceRelease_invalidReleaseName(t *testing.T) {
 				ProtoV6ProviderFactories: protoV6ProviderFactories(),
 				Steps: []resource.TestStep{
 					{
-						Config:      testAccHelmReleaseConfigInvalidName(testResourceName, namespace, name),
+						Config:      testAccHelmReleaseConfigInvalidNamePlan(testResourceName, namespace, name),
 						PlanOnly:    true,
 						ExpectError: regexp.MustCompile(`Invalid Helm Release Name`),
 					},
@@ -917,7 +917,7 @@ func testAccHelmReleaseConfigBasic(resource, ns, name, version string) string {
 	`, resource, name, ns, testRepositoryURL, version)
 }
 
-func testAccHelmReleaseConfigInvalidName(resource, ns, name string) string {
+func testAccHelmReleaseConfigInvalidNamePlan(resource, ns, name string) string {
 	return fmt.Sprintf(`
         resource "helm_release" "%s" {
             name       = %q


### PR DESCRIPTION
### Description

Addresses #1619

This PR enhances the helm_release resource by adding explicit validation for the name field in the ModifyPlan method. This ensures that invalid Helm release names are caught earlier (during planning), rather than surfacing later during apply.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
