### PR TITLE
Update index.md - remove `=`s from provider configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -143,12 +143,12 @@ For example, to [authenticate with GKE](https://registry.terraform.io/providers/
 
 ```terraform
 provider "helm" {
-    kubernetes = {
+    kubernetes {
         host  = "https://${data.google_container_cluster.my_cluster.endpoint}"
         token = data.google_client_config.provider.access_token
         cluster_ca_certificate = base64decode(
         data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,)
-        exec = {
+        exec {
             api_version = "client.authentication.k8s.io/v1beta1"
             command     = "gke-gcloud-auth-plugin"
         }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Not sure if this specific to my version of provider or terraform but I couldn't get the helm provider working as described in the docs until I removed these equals signs. Assuming that would be relevant to all other similar instances in the docs, if this is indeed a typo?

Screenshot of it failing for me.
![image](https://github.com/user-attachments/assets/00fdd31d-b815-4412-a425-7251d3120833)

### Acceptance tests
- Only changed docs


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
