### PR TITLE
HOTFIX: fix v3 state upgrader  type

### DIFF
--- a/.changelog/1638.txt
+++ b/.changelog/1638.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: Fix wrong type for "values" field in v3 state upgrader
+```

--- a/helm/resource_helm_release_stateupgrader.go
+++ b/helm/resource_helm_release_stateupgrader.go
@@ -103,7 +103,7 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 						"status":                     tftypes.String,
 						"timeout":                    tftypes.Number,
 						"upgrade_install":            tftypes.String,
-						"values":                     tftypes.String,
+						"values":                     tftypes.List{ElementType: tftypes.String},
 						"verify":                     tftypes.Bool,
 						"version":                    tftypes.String,
 						"wait":                       tftypes.Bool,
@@ -111,7 +111,7 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 					},
 				}
 
-				//Unmarshalling the old raw state as old type
+				// Unmarshalling the old raw state as old type
 				oldRawValue, err := req.RawState.Unmarshal(oldType)
 				if err != nil {
 					resp.Diagnostics.AddError("Failed to unmarshal prior state", err.Error())
@@ -249,7 +249,7 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 						"set_wo_revision":            tftypes.Number,
 						"status":                     tftypes.String,
 						"timeout":                    tftypes.Number,
-						"values":                     tftypes.String,
+						"values":                     tftypes.List{ElementType: tftypes.String},
 						"verify":                     tftypes.Bool,
 						"version":                    tftypes.String,
 						"wait":                       tftypes.Bool,
@@ -315,7 +315,7 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 					resp.Diagnostics.AddError("Failed to construct upgraded state", err.Error())
 					return
 				}
-				//Providing a message to the user, informing there state has been migrated to the current framework strucuture
+				// Providing a message to the user, informing there state has been migrated to the current framework strucuture
 				resp.Diagnostics.AddWarning("UpgradeState Triggered", "Successfully migrated state from SDKv2 to Plugin Framework")
 
 				resp.DynamicValue = &dv


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes the state upgrader for v3 of the provider. The type for the `values` attribute was incorrectly set as `types.String` and should have been  `types.List{}`.

Related #1637 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
