### PR TITLE
Fix sensitive values being replaced with '(sensitive value)' in Helm deployments

### DIFF
--- a/.changelog/1644.txt
+++ b/.changelog/1644.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: Fix shallow clone bug causing nested sensitive values to be redacted in the k8s API
+```

--- a/helm/data_helm_template_test.go
+++ b/helm/data_helm_template_test.go
@@ -22,11 +22,12 @@ func TestAccDataTemplate_basic(t *testing.T) {
 		Steps: []resource.TestStep{{
 			Config: testAccDataHelmTemplateConfigBasic(testResourceName, namespace, name, "1.2.3"),
 			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr(datasourceAddress, "manifests.%", "5"),
+				resource.TestCheckResourceAttr(datasourceAddress, "manifests.%", "6"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/deployment.yaml"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/service.yaml"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/serviceaccount.yaml"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/configmaps.yaml"),
+				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/secrets.yaml"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "manifests.templates/tests/test-connection.yaml"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "manifest"),
 				resource.TestCheckResourceAttrSet(datasourceAddress, "notes"),

--- a/helm/testdata/charts/test-chart/templates/secrets.yaml
+++ b/helm/testdata/charts/test-chart/templates/secrets.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+data:
+  cloaked: {{ .Values.cloakedData.cloaked | b64enc }}

--- a/helm/testdata/charts/test-chart/values.yaml
+++ b/helm/testdata/charts/test-chart/values.yaml
@@ -77,3 +77,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cloakedData: 
+  cloaked: secret


### PR DESCRIPTION
When using set_sensitive in the helm provider, the actual values deployed to
Kubernetes were incorrectly replaced with the string '(sensitive value)' instead
of the real sensitive value.

Root cause:
The logValues() function was using maps.Clone() which only creates a shallow
copy. Since Helm values are nested maps (e.g., {'configmap': {'foo': 'test'}}),
the inner maps were shared between the original and clone. When cloakSetValues()
modified the 'cloned' map to mask sensitive values for logging, it was actually
modifying the original map that was then passed to Helm for deployment.

Fix:
- Implemented deepCloneMap() function that recursively clones nested maps
- Updated logValues() to use deepCloneMap instead of maps.Clone
- Updated setReleaseAttributes() to use deepCloneMap for consistency
- Removed unused 'maps' import

This ensures sensitive values are properly masked in logs and Terraform state
display while the actual values are correctly deployed to Kubernetes.

Fixes the issue where ConfigMaps would contain '(sensitive value)' instead of
the actual sensitive data when using set_sensitive blocks.
