### PR TITLE
helm_release: Make description attribute Computed

### DIFF
--- a/.changelog/1648.txt
+++ b/.changelog/1648.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: Fix description field causing inconsistent plan 
+```

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -261,6 +261,7 @@ func (r *HelmRelease) Metadata(ctx context.Context, req resource.MetadataRequest
 func (r *HelmRelease) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return r.buildUpgradeStateMap(ctx)
 }
+
 func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Schema to define attributes that are available in the resource",
@@ -295,6 +296,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Add a custom description",
 				PlanModifiers: []planmodifier.String{
 					suppressDescription(),


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR makes the `description` attribute computed. 

Closes #1641

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
