### PR TITLE
Fix namespace override in kubeconfig initialization

### DIFF
--- a/.changelog/1650.txt
+++ b/.changelog/1650.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+`provider`: Fix namespace override logic in Kubernetes client initialization
+```
+

--- a/helm/kubeconfig.go
+++ b/helm/kubeconfig.go
@@ -143,8 +143,6 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		}
 		if !kubernetesConfig.ConfigContextCluster.IsNull() {
 			overrides.Context.Cluster = kubernetesConfig.ConfigContextCluster.ValueString()
-			// Enforces configured release namespace
-			overrides.Context.Namespace = namespace
 		}
 	}
 
@@ -214,6 +212,11 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 				InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
 			}
 		}
+	}
+
+	overrides.Context.Namespace = "default"
+	if namespace != "" {
+		overrides.Context.Namespace = namespace
 	}
 
 	burstLimit := int(m.Data.BurstLimit.ValueInt64())


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes logic for setting the namespace when the Kubernetes client is initialized. 

Related #1646

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
