### PR TITLE
Fix invalid syntax for nested kubernetes config in provider example documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,8 +104,8 @@ provider "helm" {
 You can also configure the host, basic auth credentials, and client certificate authentication explicitly or through environment variables.
 
 ```terraform
-provider "helm" = {
-  kubernetes {
+provider "helm" {
+  kubernetes = {
     host     = "https://cluster_endpoint:port"
 
     client_certificate     = file("~/.kube/client-cert.pem")


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes a documentation error in docs/index.md where the example helm provider block used incorrect syntax for the inline `Kubernetes` configuration

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
