### PR TITLE
Restore support for KUBE_PROXY_URL environment variable

### DIFF
--- a/.changelog/1655.txt
+++ b/.changelog/1655.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`provider`: Restore support for the `KUBE_PROXY_URL` environment variable
+```

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -344,7 +344,7 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	kubeConfigContextAuthInfo := os.Getenv("KUBE_CTX_AUTH_INFO")
 	kubeConfigContextCluster := os.Getenv("KUBE_CTX_CLUSTER")
 	kubeToken := os.Getenv("KUBE_TOKEN")
-	kubeProxy := os.Getenv("KUBE_PROXY")
+	kubeProxy := os.Getenv("KUBE_PROXY_URL")
 
 	// Initialize the HelmProviderModel with values from the config
 	var config HelmProviderModel


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR restores support for the `KUBE_PROXY_URL` environment variable

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
#1653 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
