### PR TITLE
Fix devel planmodifier

### DIFF
--- a/.changelog/1656.txt
+++ b/.changelog/1656.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`helm_release`: Fix plan error when `devel = false` is set and `version` is provided
+```

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -200,7 +200,7 @@ func (m suppressDevelPlanModifier) MarkdownDescription(ctx context.Context) stri
 func (m suppressDevelPlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
 	var version types.String
 	req.Plan.GetAttribute(ctx, path.Root("version"), &version)
-	if !version.IsNull() && version.ValueString() != "" {
+	if !version.IsNull() && version.ValueString() != "" && req.ConfigValue.IsNull() {
 		resp.PlanValue = req.StateValue
 	}
 }


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Previously, the suppressDevelPlanModifier would always return the state value
for `devel` when a `version` was set, regardless of whether the user explicitly
set `devel = false`. This change ensures that we only suppress `devel` if it was not explicitly set
in the Terraform configuration

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
#1654
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
