### PR TITLE
Handle Unknown `version` during `plan`

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2036,7 +2036,9 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		plan.Version = types.StringNull()
 	}
 
-	if !config.Version.IsNull() && !config.Version.Equal(plan.Version) {
+	if config.Version.IsUnknown() {
+		plan.Version = config.Version
+	} else if !config.Version.IsNull() && !config.Version.Equal(plan.Version) {
 		if versionsEqual(config.Version.ValueString(), plan.Version.ValueString()) {
 			plan.Version = config.Version
 		} else {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

During some of our projects we actually compute the correct version to apply during `apply`-time (our reasons are a bit odd but the final version is produced by another resource after pushing the packaged Helm chart).

This is probably a bit of a niche use case, however we wondered if it would be possible to consider keeping the `version` unknown if the input string is already unknown instead of raising an error due to version mismatches. If no version is specified, the current behavior should still apply.

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
