### PR TITLE
add support for json type in helm_release set block

### DIFF
--- a/.changelog/1684.txt
+++ b/.changelog/1684.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add `"json` as a supported `type` for the `set` block
+```

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -288,7 +288,7 @@ The `set`, `set_list`, and `set_sensitive` blocks support:
 
 * `name` - (Required) full name of the variable to be set.
 * `value` - (Required; Optional for `set`) value of the variable to be set.
-* `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
+* `type` - (Optional) type of the variable to be set. Valid options are `auto`, `string` and `json`.
 
 Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to escape the `{}`, `[]`, `.`, and `,` characters twice in order for it to be parsed. `name` should also be set to the `value path`, and `value` is the desired value that will be set.
 

--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -299,7 +299,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 							Optional: true,
 							Computed: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -335,7 +335,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 						"type": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -943,6 +943,37 @@ func applySetValue(base map[string]interface{}, set SetValue) diag.Diagnostics {
 		} else {
 			base[name] = literal
 		}
+	case "json":
+		var jsonValue interface{}
+		if err := json.Unmarshal([]byte(value), &jsonValue); err != nil {
+			diags.AddError(
+				"Failed parsing JSON value",
+				fmt.Sprintf("Key %q with json value %s: %s", name, value, err),
+			)
+			return diags
+		}
+
+		pathKeys := strings.Split(name, ".")
+		m := base
+		for i, k := range pathKeys {
+			if i == len(pathKeys)-1 {
+				m[k] = jsonValue
+			} else {
+				if _, exists := m[k]; !exists {
+					m[k] = map[string]interface{}{}
+				}
+				if nested, ok := m[k].(map[string]interface{}); ok {
+					m = nested
+				} else {
+					diags.AddError(
+						"JSON merge error",
+						fmt.Sprintf("Cannot merge JSON into an non-object path %q", strings.Join(pathKeys[:i+1], ".")),
+					)
+					return diags
+				}
+			}
+		}
+
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type: %s", valueType))
 	}

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -547,7 +547,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Computed: true,
 							Default:  stringdefault.StaticString(""),
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -614,7 +614,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 						"type": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -1508,6 +1508,37 @@ func getValue(base map[string]interface{}, set setResourceModel) diag.Diagnostic
 		} else {
 			base[name] = literal
 		}
+	case "json":
+		var jsonValue interface{}
+		if err := json.Unmarshal([]byte(value), &jsonValue); err != nil {
+			diags.AddError(
+				"Failed parsing JSON value",
+				fmt.Sprintf("Key %q with json value %s: %s", name, value, err),
+			)
+			return diags
+		}
+
+		pathKeys := strings.Split(name, ".")
+		m := base
+		for i, k := range pathKeys {
+			if i == len(pathKeys)-1 {
+				m[k] = jsonValue
+			} else {
+				if _, exists := m[k]; !exists {
+					m[k] = map[string]interface{}{}
+				}
+				if nested, ok := m[k].(map[string]interface{}); ok {
+					m = nested
+				} else {
+					diags.AddError(
+						"JSON merge error",
+						fmt.Sprintf("Cannot merge JSON into an non-object path %q", strings.Join(pathKeys[:i+1], ".")),
+					)
+					return diags
+				}
+			}
+		}
+
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type: %s", valueType))
 		return diags


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR introduces a new "json" type for the `set` block in the `helm_release` resource.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

#1678

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
