### PR TITLE
fix(datasource): allow literal in set_sensitive

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -916,7 +916,7 @@ func checkChartDependenciesModel(ctx context.Context, model *HelmTemplateModel, 
 	return false, diags
 }
 
-func applySetValue(base map[string]interface{}, set SetValue) diag.Diagnostics {
+func applySetValue(base map[string]any, set SetValue) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	name := set.Name.ValueString()
@@ -933,12 +933,12 @@ func applySetValue(base map[string]interface{}, set SetValue) diag.Diagnostics {
 			diags.AddError("Failed parsing string value", fmt.Sprintf("Key %q with value %s: %s", name, value, err))
 		}
 	case "literal":
-		var literal interface{}
-		if err := yaml.Unmarshal([]byte(fmt.Sprintf("%s: %s", name, value)), &literal); err != nil {
+		var literal any
+		if err := yaml.Unmarshal(fmt.Appendf(nil, "%s: %s", name, value), &literal); err != nil {
 			diags.AddError("Failed parsing literal value", fmt.Sprintf("Key %q with literal value %s: %s", name, value, err))
 			return diags
 		}
-		if m, ok := literal.(map[string]interface{}); ok {
+		if m, ok := literal.(map[string]any); ok {
 			base[name] = m[name]
 		} else {
 			base[name] = literal
@@ -949,7 +949,7 @@ func applySetValue(base map[string]interface{}, set SetValue) diag.Diagnostics {
 	return diags
 }
 
-func applySetListValue(ctx context.Context, base map[string]interface{}, setList SetListValue) diag.Diagnostics {
+func applySetListValue(_ context.Context, base map[string]any, setList SetListValue) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	name := setList.Name.ValueString()
@@ -981,7 +981,7 @@ func applySetListValue(ctx context.Context, base map[string]interface{}, setList
 	return diags
 }
 
-func applySetSensitiveValue(base map[string]interface{}, setSensitive SetSensitiveValue) diag.Diagnostics {
+func applySetSensitiveValue(base map[string]any, setSensitive SetSensitiveValue) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	name := setSensitive.Name.ValueString()
@@ -996,6 +996,18 @@ func applySetSensitiveValue(base map[string]interface{}, setSensitive SetSensiti
 	case "string":
 		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			diags.AddError("Failed parsing sensitive string value", fmt.Sprintf("Failed parsing key %q with value %s: %s", name, value, err))
+		}
+	case "literal":
+		var literal any
+		if err := yaml.Unmarshal(fmt.Appendf(nil, "%s: %s", name, value), &literal); err != nil {
+			diags.AddError("Failed parsing sensitive literal value", fmt.Sprintf("Key %q with literal value %s: %s", name, value, err))
+			return diags
+		}
+
+		if m, ok := literal.(map[string]any); ok {
+			base[name] = m[name]
+		} else {
+			base[name] = literal
 		}
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type for sensitive value: %s", valueType))

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -86,8 +85,7 @@ func TestAccResourceRelease_set_wo(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			// FIXME use const from terraform-plugin-testing once v1.11.0 is released.
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+			tfversion.SkipBelow(tfversion.Version1_11_0),
 		},
 		// PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: protoV6ProviderFactories(),


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Permit literal values in `set_sensitive` for `helm_release` data source.
The [schema](https://github.com/hashicorp/terraform-provider-helm/blob/c8c5571ee1d6699b2b615d07dcc669318e7f121b/helm/data_helm_template.go#L338) already allowed this, but the implementation did not handle it.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note:bug
`datasource/helm_release`: Implemented `set_sensitive` with literal type
```
### References

#1615

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
