### PR TITLE
fix inconsistent result after apply

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2291,6 +2291,9 @@ func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
 	if !plan.Repository.Equal(state.Repository) {
 		return true
 	}
+	if !plan.Version.Equal(state.Version) {
+		return true
+	}
 	if !plan.Values.Equal(state.Values) {
 		return true
 	}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Simply revert the commit, it's only 3 lines of code.

## Changes to Security Controls

None

### Description

When upgrading a Helm chart to a new version, the provider threw errors like:
```
Error: Provider produced inconsistent result after apply
.metadata.version: was cty.StringVal("0.1.0"), but now cty.StringVal("0.1.1")
.metadata.revision: was cty.NumberIntVal(1), but now cty.NumberIntVal(2)
.metadata.last_deployed: was cty.NumberIntVal(1.759344053e+09), but now cty.NumberIntVal(1.759344075e+09).
.metadata.app_version: was cty.StringVal("1.1"), but now cty.StringVal("1.2").
```

Added a version check to the recomputeMetadata() function:
```go
if !plan.Version.Equal(state.Version) {
    return true
}
```


### Acceptance tests
None, I just tested locally and confirmed I reproduced the bug with the official v3.0.2, and then tested again with the fix to confirm it works.


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
Fix `Provider produced inconsistent result after apply` error when upgrading an helm chart with v3.0.2
```
### References

Fixes issues https://github.com/hashicorp/terraform-provider-helm/issues/1692 and https://github.com/hashicorp/terraform-provider-helm/issues/1664

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
