### PR TITLE
fix: Address "inconsistent result after apply" error by moving metadata recalc

### DIFF
--- a/.changelog/1713.txt
+++ b/.changelog/1713.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/helm_release`: Fix "inconsistent result after apply" error by moving recomputeMetadata function call
+```


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Simply revert the commit, there are no schema changes.

## Changes to Security Controls

None

### Description

<!--- Please leave a helpful description of the pull request here. --->

It seems that you check for metadata recompute too early. The version of the state and the plan matches already and thus the helper function `func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool { }` is not able to resolve the version update of the chart in all cases we evauluate in the lines below.

By moving the whole block to the end, it seems that the plan is updated for several version update cases.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

```bash
$ kind get clusters
testing

$ kubectl get nodes
NAME                         STATUS   ROLES           AGE   VERSION
testing-control-plane        Ready    control-plane   14d   v1.34.0

$ make testacc
...
ok  	github.com/hashicorp/terraform-provider-helm/helm	389.272s
```

Plus manual testing:

Before:
```bash
$ terraform plan
helm_release.my_local_chart: Refreshing state... [id=my-local-chart]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # helm_release.my_local_chart will be updated in-place
  ~ resource "helm_release" "my_local_chart" {
        id                         = "my-local-chart"
        name                       = "my-local-chart"
      ~ version                    = "1.10.16" -> "1.10.17"
        # (26 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

After:
```bash
$ TF_REATTACH_PROVIDERS='{"registry.terraform.io/hashicorp/helm":{"Protocol":"grpc","ProtocolVersion":6,"Pid":60272,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/8q/8b5t1wjn0sggk1vrzb82t7tw0000gn/T/plugin1683805268"}}}' terraform plan
helm_release.my_local_chart: Refreshing state... [id=my-local-chart]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # helm_release.my_local_chart will be updated in-place
  ~ resource "helm_release" "my_local_chart" {
      ~ id                         = "my-local-chart" -> (known after apply)
      ~ metadata                   = {
          + app_version    = (known after apply)
          ~ chart          = "my-local-chart" -> (known after apply)
          ~ first_deployed = 1761168691 -> (known after apply)
          ~ last_deployed  = 1761175638 -> (known after apply)
          ~ name           = "my-local-chart" -> (known after apply)
          ~ namespace      = "testing" -> (known after apply)
          + notes          = (known after apply)
          ~ revision       = 16 -> (known after apply)
          ~ values         = jsonencode({}) -> (known after apply)
          ~ version        = "1.10.16" -> (known after apply)
        } -> (known after apply)
        name                       = "my-local-chart"
      + take_ownership             = false
      + upgrade_install            = false
      ~ version                    = "1.10.16" -> "1.10.17"
        # (25 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Address "inconsistent result after apply" error by moving recomputeMetadata() function
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Fixes #1664
Fixes #1692

Related to:
- https://github.com/hashicorp/terraform-provider-helm/pull/1708
- #1694

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
