### PR TITLE
fix keyring bug

### DIFF
--- a/helm/resource_helm_release_stateupgrader.go
+++ b/helm/resource_helm_release_stateupgrader.go
@@ -155,6 +155,17 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 					}
 				}
 
+				normalizeKeyring := func(val tftypes.Value) tftypes.Value {
+					if val.IsNull() {
+						return tftypes.NewValue(tftypes.String, nil)
+					}
+					var str string
+					if err := val.As(&str); err == nil && str == "" {
+						return tftypes.NewValue(tftypes.String, nil)
+					}
+					return val
+				}
+
 				// Creating new type in FW
 				newType := tftypes.Object{
 					AttributeTypes: map[string]tftypes.Type{
@@ -293,7 +304,7 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 					"disable_webhooks":           oldState["disable_webhooks"],
 					"force_update":               oldState["force_update"],
 					"id":                         oldState["id"],
-					"keyring":                    oldState["keyring"],
+					"keyring":                    normalizeKeyring(oldState["keyring"]),
 					"lint":                       oldState["lint"],
 					"manifest":                   oldState["manifest"],
 					"max_history":                oldState["max_history"],


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This pr Fixes the "Provider produced invalid plan" error that occurs when upgrading from provider v2.x to v3.x with `keyring` attribute set to empty string or null.

the pr normalizes empty string keyring values to null during state migration 
from v2 to v3 to match user configurations.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
#1695 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
