### PR TITLE
Fix nil pointer crash when updating OCI chart dependencies

### DIFF
--- a/.changelog/xxxx.txt
+++ b/.changelog/xxxx.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix nil pointer dereference crash when downloading OCI chart dependencies with dependency_update enabled
+```

--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -947,6 +947,7 @@ func checkChartDependenciesModel(ctx context.Context, model *HelmTemplateModel, 
 					Getters:          p,
 					RepositoryConfig: meta.Settings.RepositoryConfig,
 					RepositoryCache:  meta.Settings.RepositoryCache,
+					RegistryClient:   meta.RegistryClient,
 					Debug:            meta.Settings.Debug,
 				}
 				tflog.Debug(ctx, "Downloading chart dependencies...")

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1901,6 +1901,7 @@ func checkChartDependencies(ctx context.Context, model *HelmReleaseModel, c *cha
 					Getters:          p,
 					RepositoryConfig: m.Settings.RepositoryConfig,
 					RepositoryCache:  m.Settings.RepositoryCache,
+					RegistryClient:   m.RegistryClient,
 					Debug:            m.Settings.Debug,
 				}
 				tflog.Debug(ctx, "Downloading chart dependencies...")


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This fix only adds the already-configured `RegistryClient` to the downloader Manager, enabling existing authentication to work correctly.

### Description

When dependency_update is enabled and chart dependencies use OCI registries, the `downloader.Manager` was created without the `RegistryClient` field set. This caused a nil pointer dereference when the downloader tried to resolve version constraints (such as `~1.0.0`) that require listing tags from the registry.

The fix adds `RegistryClient` to the Manager initialization in both:

- `resource_helm_release.go`
- `data_helm_template.go`
- 
This allows the downloader to properly authenticate and communicate with OCI registries when fetching chart dependencies.

**Error before the fix:**

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x1f6c4c6]

goroutine 83 [running]:
helm.sh/helm/v3/pkg/registry.(*Client).Tags(0x0, ...)
    helm.sh/helm/v3@v3.18.4/pkg/registry/client.go:848 +0x1a6
helm.sh/helm/v3/internal/resolver.(*Resolver).Resolve(...)
    helm.sh/helm/v3@v3.18.4/internal/resolver/resolver.go:152 +0x59d
helm.sh/helm/v3/pkg/downloader.(*Manager).Update(...)
```

### Acceptance tests
- [x] Tested manually with OCI registry (GitLab Container Registry)
- [x] Chart dependencies with version constraints `~1.0.0` and `>=1.0.0 <2.0.0`
- [x] Provider configured with `registries` block for authentication (`oci://registry.gitlab.com`)
- [x] Set `dependency_update = true` in `helm_release` resource
- [x] Previously crashed with nil pointer, now successfully downloads dependencies

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix nil pointer dereference crash when downloading OCI chart dependencies with dependency_update enabled
```
### References

This issue affects users who:

- Use OCI registries for Helm charts (e.g., `oci://registry.gitlab.com`)
- Have `dependency_update = true` in their helm_release resource
- Use semantic version constraints in `Chart.yaml` dependencies (e.g., ~1.0.0, >=1.0.0)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
