### PR TITLE
DRAFT: Add test for `values=` receiving sensitive content

### DIFF
--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -434,6 +434,50 @@ func TestAccResourceRelease_cloakValues(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_honorSensitive(t *testing.T) {
+	name := randName("test-update-values")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	secretValue := "foobar"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfigSensitiveValuesYaml(
+					testResourceName, namespace, name, "test-chart", "1.2.3", secretValue,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.values", `{"cloakedData":{"cloaked":"(sensitive value)"}}`),
+					func(s *terraform.State) error {
+						c, err := createKubernetesClient()
+						if err != nil {
+							return err
+						}
+
+						res, err := c.CoreV1().Secrets(namespace).Get(context.Background(), fmt.Sprintf("%s-test-chart", name), v1.GetOptions{})
+						if err != nil {
+							return err
+						}
+
+						v, ok := res.Data["cloaked"]
+						if !ok {
+							return fmt.Errorf("expected %q but secret value was nil", secretValue)
+						}
+
+						if string(v) != secretValue {
+							return fmt.Errorf("expected secret value to be %q but got %q", secretValue, v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
 func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 	name := randName("test-update-multiple-values")
 	namespace := createRandomNamespace(t)
@@ -1244,6 +1288,20 @@ func testAccHelmReleaseConfigSensitiveValue(resource, ns, name, chart, version, 
 			]
 		}
 	`, resource, ns, name, testRepositoryURL, chart, version, key, value)
+}
+
+func testAccHelmReleaseConfigSensitiveValuesYaml(resource, ns, name, chart, version, value string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+			namespace  = %q
+			name       = %q
+			repository = %q
+			chart      = %q
+			version    = %q
+
+			values = [sensitive("password: %s")]
+		}
+	`, resource, ns, name, testRepositoryURL, chart, version, value)
 }
 
 func testAccHelmReleaseConfigSet(resource, ns, name, version, setValue string) string {


### PR DESCRIPTION
### Description

Adding a test.  Currently expected to fail (demonstrating bug).  Written naively (at least as far as `terraform-provider-helm` testing goes).

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

In fact, only that.

### References

- https://github.com/hashicorp/terraform-provider-helm/issues/1287

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
