### PR TITLE
fix(helm_release): Preserve Terraform state on failed Helm operations (#1669)

### DIFF
--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -800,7 +800,7 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
-					resource.TestCheckResourceAttr("helm_release.test", "status", "FAILED"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusFailed.String()),
 				),
 			},
 			// Step 3: Re-apply same invalid config - should NOT produce "cannot re-use a name" error
@@ -819,7 +819,7 @@ func TestAccResourceRelease_updateExistingFailed(t *testing.T) {
 					[]string{"serviceAccount:\n  name: recovered-name"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "4"),
 					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
 				),
 			},
@@ -853,7 +853,6 @@ func TestAccResourceRelease_statePreservedDuringRefresh(t *testing.T) {
 			},
 			// Step 2: Run refresh (via RefreshState) - resource should remain in state
 			{
-				Config:       config,
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
@@ -905,19 +904,15 @@ func TestAccResourceRelease_refreshPreservesFailedState(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
-					resource.TestCheckResourceAttr("helm_release.test", "status", "FAILED"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusFailed.String()),
 				),
 			},
 			// Step 3: Run refresh - FAILED release should remain in state
 			{
-				Config: testAccHelmReleaseConfigValues(
-					testResourceName, namespace, name, "test-chart", "1.2.3",
-					[]string{"service:\n  type: invalid%-$type"},
-				),
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "status", "FAILED"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusFailed.String()),
 				),
 			},
 		},
@@ -963,7 +958,7 @@ func TestAccResourceRelease_comprehensiveReleaseDetection(t *testing.T) {
 				ExpectError:        regexp.MustCompile("Unsupported value"),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "status", "FAILED"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusFailed.String()),
 					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "3"),
 				),
 			},


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this pull request.

### Description

This PR fixes a critical bug where `helm_release` resources are randomly removed from Terraform state after failed deployments or during refresh operations. This issue causes subsequent `terraform apply` runs to fail with the error "cannot re-use a name that is still in use" because Terraform attempts to recreate releases that already exist in the Kubernetes cluster but are no longer tracked in state.

**Root Causes Addressed:**

1. **Update Function (Primary Fix)**: When a Helm upgrade fails, the function now saves state before returning an error. Previously, it returned immediately without updating state, causing state loss when combined with subsequent Read operations.

2. **Create Function**: Added state persistence before returning error on failed create to prevent orphaning releases from Terraform tracking.

3. **Read Function**: Improved error handling order and added informative logging when removing resources from state.

4. **resourceReleaseExists Function**: Completely rewritten to use `action.List` instead of `getRelease` to detect releases in ALL states (deployed, failed, pending-install, pending-upgrade, etc.). This is more comprehensive and prevents false negatives that led to state removal.

**Changes Summary:**
- `helm/resource_helm_release.go`: Enhanced error handling in Create, Read, and Update functions to preserve state on failures; rewrote `resourceReleaseExists` for comprehensive release detection
- `helm/resource_helm_release_test.go`: Added 8 new acceptance tests covering various failure scenarios

Fixes #1669

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

**New Acceptance Tests:**
- `TestAccResourceRelease_updateExistingFailed` - Tests failed deployment preserves state and recovery
- `TestAccResourceRelease_statePreservedDuringRefresh` - Tests state not removed during refresh
- `TestAccResourceRelease_refreshPreservesFailedState` - Tests refresh preserves failed release state
- `TestAccResourceRelease_comprehensiveReleaseDetection` - Tests release detection in all states
- `TestAccResourceRelease_failedInitialDeployPreservesState` - Tests failed initial deployment preserves state
- `TestAccResourceRelease_failedInitialDeployAtomicNoState` - Tests atomic=true behavior on failed installation
- `TestAccResourceRelease_deleteOperationCorrectBehavior` - Tests delete operation maintains correct behavior
- `TestAccResourceRelease_deleteAlreadyRemovedRelease` - Tests delete handles already-removed release gracefully


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
bug: Fix helm_release resources being randomly removed from Terraform state after failed deployments or during refresh operations (#1669)
```
### References

- GitHub Issue: #1669

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
