### PR TITLE
Fallback to local object when server-side apply fails with authentication error

### DIFF
--- a/helm/kube_resources.go
+++ b/helm/kube_resources.go
@@ -258,40 +258,6 @@ func getLiveResources(ctx context.Context, r *release.Release, m *Meta) (map[str
 	return cleaned, diags
 }
 
-func getDryRunResourcesClientSide(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	actionConfig, err := m.GetHelmConfiguration(ctx, r.Namespace)
-	if err != nil {
-		diags.AddError("Helm Config Error", err.Error())
-		return nil, diags
-	}
-
-	rawResources, resDiags := mapResources(ctx, actionConfig, r, func(i *resource.Info) (runtime.Object, error) {
-		return i.Object, nil
-	})
-	diags.Append(resDiags...)
-	if resDiags.HasError() {
-		return rawResources, diags
-	}
-	cleaned := make(map[string]string, len(rawResources))
-	for k, v := range rawResources {
-		var obj map[string]any
-		if err := json.Unmarshal([]byte(v), &obj); err != nil {
-			cleaned[k] = v
-			continue
-		}
-		normalizeK8sObject(obj)
-		if b, err := json.Marshal(obj); err == nil {
-			cleaned[k] = string(b)
-		} else {
-			cleaned[k] = v
-		}
-	}
-
-	return cleaned, diags
-}
-
 func getDryRunResources(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

<!--- Please leave a helpful description of the pull request here. --->

Since `v3.1.0` the provider uses server-side apply to get resource diffs (see [here](https://github.com/hashicorp/terraform-provider-helm/issues/1735#issuecomment-3705508887)). This approach fails if read-only kubernetes credentials are used for Terraform plan phase, because kubernetes will already validate permissions for all operations.

With this change, the provider falls back to the local object definition (as in `v3.0.2`) whenever it receives a `Forbidden` error from the API during server-side apply.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fall back to local object if permissions for server-side apply are missing
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Solves issue https://github.com/hashicorp/terraform-provider-helm/issues/1735

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
