### PR TITLE
Mark metadata.values as sensitive to avoid secret leaks

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -403,7 +403,8 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 					},
 					"values": schema.StringAttribute{
 						Computed:    true,
-						Description: "Set of extra values. added to the chart. The sensitive data is cloaked. JSON encoded.",
+						Sensitive:   true,
+						Description: "Set of extra values added to the chart, marked as sensitive to avoid revealing potential secrets passed as values.",
 					},
 					"version": schema.StringAttribute{
 						Computed:    true,


### PR DESCRIPTION
### Description

For a very long time, the Helm provider has been leaking secrets and sensitive values passed via the `values` block (see multiple linked issues).

When the `values` block itself is correctly marked as sensitive, any diff in values is correctly suppressed in the output. However, the helm provider will still display values changes as a change in the `metadata` block, in plain text, therefore leaking any sensitive value that is present in there.

This is particularly bad when using systems that display the output of `terraform plan` or `terraform apply`, like [atlantis](https://www.runatlantis.io/), as your secrets are now leaked to e.g. Github (yikes!!).

[A workaround is to use `set_sensitive`](https://github.com/hashicorp/terraform-provider-helm/issues/1221#issuecomment-1681940842), but:
1. The idiomatic and most common way to configure helm charts is to pass a values file, either encoded via `yamlencode()` or templated via `templatefile()`
2. The syntax to define paths in `set` / `set_sensitive` is very awkward, espeically with nested arrays/objects
3. Even if that workaround exists, we're still leaking secrets passed through `values`!

### Implementation of the fix

In this PR, I mark the output of `metadata.values` as sensitive regardless of whether it is known to contain sensitive values or not.

Note that this was suggested by @apparentlymart in [this comment](https://github.com/hashicorp/terraform-provider-helm/issues/793#issuecomment-1061004986). I believe that the provider upgrade from 2.x to 3.x changed the metadata schema a bit so that we can now choose to mark `metadata.values` as sensitive rather than the whole `metadata` block.

We cannot reuse the sensitivity of the `values` field here, as the original content of `metadata.values` (before a plan/apply) are read from k8s, and the provider has no way to know at this stage whether these values were sensitive or not.

However, I'm convinced to is a fine change and will not affect the plugin functionality because:
- diffs will still be visible on the `values` field, as they should be
- while `metadata.values` is marked as sensitive, all other metadata fields are still shown as before

Some examples:

1. In-place upgrade containing secrets

Before:

<img width="744" height="351" alt="Screenshot 2026-01-09 at 11 57 36" src="https://github.com/user-attachments/assets/f46a767d-bb85-462c-917c-ef7b729e12c3" />

After:

<img width="689" height="387" alt="Screenshot 2026-01-09 at 11 58 12" src="https://github.com/user-attachments/assets/cc5b8b43-4edb-43e5-88e2-d41f3ce74dc0" />

2. `helm_release` deletion

Before:

<img width="696" height="572" alt="Screenshot 2026-01-09 at 11 59 04" src="https://github.com/user-attachments/assets/a361bcf3-1935-4eca-a69a-c00e4d47a77a" />

After:

<img width="669" height="597" alt="Screenshot 2026-01-09 at 11 58 26" src="https://github.com/user-attachments/assets/327ac6bc-761f-4169-afeb-7dca95790b77" />

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

No, the change it output-only. But if we test that too I'm happy to add them!

### Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
Mark metadata.values as sensitive to prevent leaking secrets on chart updates & deletion
```

### References

Fixes #793
Fixes #1221
Fixes #1287
Fixes #1737 

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment