### PR TITLE
fix nil ref panic

### DIFF
--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -2312,7 +2312,11 @@ func TestAccResourceRelease_OCI_repository(t *testing.T) {
 	defer deleteNamespace(t, namespace)
 
 	ociRegistryURL, shutdown := setupOCIRegistry(t, false)
-	defer shutdown()
+	defer func() {
+		if shutdown != nil {
+			shutdown()
+		}
+	}()
 
 	resource.Test(t, resource.TestCase{
 		//PreCheck: func() {
@@ -2362,7 +2366,11 @@ func TestAccResourceRelease_OCI_registry_login(t *testing.T) {
 	defer deleteNamespace(t, namespace)
 
 	ociRegistryURL, shutdown := setupOCIRegistry(t, false)
-	defer shutdown()
+	defer func() {
+		if shutdown != nil {
+			shutdown()
+		}
+	}()
 
 	resource.Test(t, resource.TestCase{
 		//PreCheck: func() {
@@ -2412,7 +2420,11 @@ func TestAccResourceRelease_OCI_login(t *testing.T) {
 	defer deleteNamespace(t, namespace)
 
 	ociRegistryURL, shutdown := setupOCIRegistry(t, true)
-	defer shutdown()
+	defer func() {
+		if shutdown != nil {
+			shutdown()
+		}
+	}()
 
 	resource.Test(t, resource.TestCase{
 		//PreCheck: func() {


### PR DESCRIPTION
## Rollback Plan

This is a minor fix to the tests - revert and try another fix.

## Changes to Security Controls

None

### Description

I noticed some panics while running acceptance tests

```plain
--- FAIL: TestAccResourceRelease_OCI_repository (5.91s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

### Acceptance tests

No, I'm just fixing a few.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
Bug fix in acceptance test
```
### References

N/A

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
