### PR TITLE
Set HELM_EXPERIMENTAL_OCI for OCI acceptance test

### DIFF
--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -2287,6 +2287,7 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	cmd = exec.Command(helmPath, "push",
 		"test-chart-1.2.3.tgz",
 		ociRegistryURL)
+	cmd.Env = append(os.Environ(), "HELM_EXPERIMENTAL_OCI=1")
 	out, err = cmd.CombinedOutput()
 	t.Log(string(out))
 	if err != nil {


### PR DESCRIPTION
## Rollback Plan

This is a minor fix to the tests - revert and try another fix.

## Changes to Security Controls

None

### Description

I noticed this error while running acceptance tests

```plain
resource_helm_release_test.go:2286: pushing test-chart to OCI registry
    resource_helm_release_test.go:2291: Error: this feature has been marked as experimental and is not enabled by default. Please set HELM_EXPERIMENTAL_OCI=1 in your environment to use this feature
        exit status 1
```

### Acceptance tests

No, I'm just fixing one.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
Bug fix in acceptance test
```

### References

N/A

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
