### PR TITLE
fix(manifest-experiment): strip data from secret during normalization

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2632,6 +2632,14 @@ func stripSecretManagedByLabel(obj map[string]any) {
 	}
 }
 
+func stripSecretData(obj map[string]any) {
+	if kind, _ := obj["kind"].(string); kind != "Secret" {
+		return
+	}
+	delete(obj, "data")
+	delete(obj, "stringData")
+}
+
 func normalizeStatus(obj map[string]any) {
 	kind, _ := obj["kind"].(string)
 	if kind == "Deployment" {
@@ -2646,5 +2654,6 @@ func normalizeK8sObject(obj map[string]any) {
 	stripHelmMetaAnnotations(obj)
 	stripVolatileFields(obj)
 	stripSecretManagedByLabel(obj)
+	stripSecretData(obj)
 	normalizeStatus(obj)
 }

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -2950,6 +2950,55 @@ provider "helm" {
 	})
 }
 
+func TestAccResourceRelease_manifestSecretDataMutation(t *testing.T) {
+	name := randName("secretdiff")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	provider := `
+provider "helm" {
+  experiments = { manifest = true }
+}
+`
+	secretKey := "cloakedData.cloaked"
+	secretValue := "initial-secret"
+	config := provider + testAccHelmReleaseConfigSensitiveValue(
+		testResourceName, namespace, name, "test-chart", "1.2.3", secretKey, secretValue,
+	)
+	secretName := fmt.Sprintf("%s-test-chart", name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					checkSecretResourceDataStripped("helm_release.test", namespace, secretName),
+					func(state *terraform.State) error {
+						t.Logf("fetching live JSON resources for %s/%s", namespace, name)
+						r := getReleaseJSONResourcesPF(t, namespace, name)
+						return checkResourceAttrMap("helm_release.test", "resources", r)(state)
+					},
+				),
+			},
+			{
+				PreConfig: patchSecretDataPF(t, namespace, secretName, "server.secretkey", "rotated-by-controller"),
+				Config:    config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkSecretResourceDataStripped("helm_release.test", namespace, secretName),
+					func(state *terraform.State) error {
+						t.Logf("fetching live JSON resources for %s/%s", namespace, name)
+						r := getReleaseJSONResourcesPF(t, namespace, name)
+						return checkResourceAttrMap("helm_release.test", "resources", r)(state)
+					},
+				),
+			},
+		},
+	})
+}
+
 func checkResourceAttrMap(resourceName, key string, expected map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -2970,6 +3019,53 @@ func checkResourceAttrMap(resourceName, key string, expected map[string]string) 
 			if got, ok := attrs[attrKey]; !ok || got != v {
 				return fmt.Errorf("expected %s=%q but got %q", attrKey, v, got)
 			}
+		}
+		return nil
+	}
+}
+
+func patchSecretDataPF(t *testing.T, namespace, name, key, value string) func() {
+	return func() {
+		kc := getTestKubeClientPF(t, namespace)
+		client, err := kc.Factory.KubernetesClientSet()
+		if err != nil {
+			t.Fatalf("failed to create kubernetes clientset: %v", err)
+		}
+		secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), name, v1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get secret: %v", err)
+		}
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[key] = []byte(value)
+		if _, err := client.CoreV1().Secrets(namespace).Update(context.Background(), secret, v1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to update secret: %v", err)
+		}
+	}
+}
+
+func checkSecretResourceDataStripped(resourceName, namespace, secretName string) resource.TestCheckFunc {
+	secretKey := fmt.Sprintf("resources.secret/v1/%s/%s", namespace, secretName)
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		val, ok := rs.Primary.Attributes[secretKey]
+		if !ok {
+			return fmt.Errorf("attribute %s not found in state", secretKey)
+		}
+
+		var secret map[string]any
+		if err := json.Unmarshal([]byte(val), &secret); err != nil {
+			return fmt.Errorf("failed to unmarshal secret JSON: %w", err)
+		}
+		if _, exists := secret["data"]; exists {
+			return fmt.Errorf("expected secret resource %s to not contain data field", secretKey)
+		}
+		if _, exists := secret["stringData"]; exists {
+			return fmt.Errorf("expected secret resource %s to not contain stringData field", secretKey)
 		}
 		return nil
 	}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
This PR adds stripping of the Secret Data of a Secret to avoid `Error: Provider produced inconsistent result after apply` in case that the secret has been altered since its initial Terraform plan/diff. This only happens when `manifest=experiement` is enabled.

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
strip secret data when normalising a kubernetes object to avoid inconsistent result after apply when secret is mutating during installation
```
### References
- https://github.com/argoproj/argo-helm/issues/3744

Similar issues related to the `manifest` experiment, but not related to a mutating secret:
- https://github.com/hashicorp/terraform-provider-helm/issues/829 
- https://github.com/hashicorp/terraform-provider-helm/issues/1581 
- https://github.com/hashicorp/terraform-provider-helm/issues/805


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
