### PR TITLE
Oci login rotated credentials test

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1106,7 +1106,7 @@ func (r *HelmRelease) Update(ctx context.Context, req resource.UpdateRequest, re
 		resp.Diagnostics.AddError("Error getting helm configuration", fmt.Sprintf("Unable to get Helm configuration for namespace %s: %s", namespace, err))
 		return
 	}
-	ociDiags := OCIRegistryLogin(ctx, meta, actionConfig, meta.RegistryClient, state.Repository.ValueString(), state.Chart.ValueString(), state.RepositoryUsername.ValueString(), state.RepositoryPassword.ValueString())
+	ociDiags := OCIRegistryLogin(ctx, meta, actionConfig, meta.RegistryClient, plan.Repository.ValueString(), plan.Chart.ValueString(), plan.RepositoryUsername.ValueString(), plan.RepositoryPassword.ValueString())
 	resp.Diagnostics.Append(ociDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -2199,7 +2199,7 @@ func testAccHelmReleaseConfigWithTimeouts(resource, ns, name, version string) st
 	`, resource, name, ns, testRepositoryURL, version)
 }
 
-func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
+func setupOCIRegistry(t *testing.T, usepassword bool) (string, string, func()) {
 	dockerPath, err := exec.LookPath("docker")
 	if err != nil {
 		t.Skip("Starting the OCI registry requires docker to be installed in the PATH")
@@ -2236,7 +2236,7 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	t.Log(string(out))
 	if err != nil {
 		t.Errorf("Failed to start OCI registry: %v", err)
-		return "", nil
+		return "", "", nil
 	}
 	// wait a few seconds for the server to start
 	t.Log("Waiting for registry to start...")
@@ -2248,7 +2248,7 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	t.Log(string(out))
 	if err != nil {
 		t.Errorf("Failed to get port for OCI registry: %v", err)
-		return "", nil
+		return "", "", nil
 	}
 
 	portOutput := strings.Split(string(out), "\n")[0]
@@ -2264,7 +2264,7 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	t.Log(string(out))
 	if err != nil {
 		t.Errorf("Failed to package chart: %v", err)
-		return "", nil
+		return "", "", nil
 	}
 
 	if usepassword {
@@ -2278,7 +2278,7 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 		t.Log(string(out))
 		if err != nil {
 			t.Errorf("Failed to login to OCI registry: %v", err)
-			return "", nil
+			return "", "", nil
 		}
 	}
 
@@ -2291,10 +2291,10 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	t.Log(string(out))
 	if err != nil {
 		t.Errorf("Failed to push chart: %v", err)
-		return "", nil
+		return "", "", nil
 	}
 
-	return ociRegistryURL, func() {
+	return ociRegistryURL, registryContainerName, func() {
 		t.Log("stopping OCI registry")
 		cmd := exec.Command(dockerPath, "rm",
 			"--force", registryContainerName)
@@ -2306,12 +2306,32 @@ func setupOCIRegistry(t *testing.T, usepassword bool) (string, func()) {
 	}
 }
 
+// rotateOCIRegistryCredentials replaces the htpasswd file inside a running
+// OCI registry container with a new fixture. The distribution registry reads
+// htpasswd per request, so no container restart is needed.
+func rotateOCIRegistryCredentials(t *testing.T, containerName, htpasswdFixture string) {
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		t.Fatalf("docker not found in PATH: %v", err)
+	}
+	wd, _ := os.Getwd()
+	src := path.Join(wd, htpasswdFixture)
+	cmd := exec.Command(dockerPath, "cp", src,
+		fmt.Sprintf("%s:/etc/docker/registry/auth.htpasswd", containerName))
+	out, err := cmd.CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("Failed to rotate htpasswd: %v", err)
+	}
+	t.Logf("Rotated OCI registry credentials using %s", htpasswdFixture)
+}
+
 func TestAccResourceRelease_OCI_repository(t *testing.T) {
 	name := randName("oci")
 	namespace := createRandomNamespace(t)
 	defer deleteNamespace(t, namespace)
 
-	ociRegistryURL, shutdown := setupOCIRegistry(t, false)
+	ociRegistryURL, _, shutdown := setupOCIRegistry(t, false)
 	defer shutdown()
 
 	resource.Test(t, resource.TestCase{
@@ -2361,7 +2381,7 @@ func TestAccResourceRelease_OCI_registry_login(t *testing.T) {
 	namespace := createRandomNamespace(t)
 	defer deleteNamespace(t, namespace)
 
-	ociRegistryURL, shutdown := setupOCIRegistry(t, false)
+	ociRegistryURL, _, shutdown := setupOCIRegistry(t, false)
 	defer shutdown()
 
 	resource.Test(t, resource.TestCase{
@@ -2411,7 +2431,7 @@ func TestAccResourceRelease_OCI_login(t *testing.T) {
 	namespace := createRandomNamespace(t)
 	defer deleteNamespace(t, namespace)
 
-	ociRegistryURL, shutdown := setupOCIRegistry(t, true)
+	ociRegistryURL, _, shutdown := setupOCIRegistry(t, true)
 	defer shutdown()
 
 	resource.Test(t, resource.TestCase{
@@ -2436,6 +2456,72 @@ func TestAccResourceRelease_OCI_login(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccResourceRelease_OCI_login_rotated_credentials reproduces the
+// regression from issues #1645 and #1660: when a helm_release is updated
+// after its repository credentials change (e.g. a rotated short-lived token
+// from AWS Public ECR or Azure ACR), the Update path must send the new
+// credentials from the plan rather than the stale ones from state.
+func TestAccResourceRelease_OCI_login_rotated_credentials(t *testing.T) {
+	name := randName("oci")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	ociRegistryURL, containerName, shutdown := setupOCIRegistry(t, true)
+	defer shutdown()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfig_OCI_login_with_set(
+					testResourceName, namespace, name, ociRegistryURL, "1.2.3",
+					"hashicorp", "terraform", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+				),
+			},
+			{
+				PreConfig: func() {
+					rotateOCIRegistryCredentials(t, containerName, "testdata/oci_registry/auth2.htpasswd")
+				},
+				Config: testAccHelmReleaseConfig_OCI_login_with_set(
+					testResourceName, namespace, name, ociRegistryURL, "1.2.3",
+					"hashicorp2", "terraform2", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+					resource.TestCheckResourceAttr("helm_release.test", "set.0.name", "replicaCount"),
+					resource.TestCheckResourceAttr("helm_release.test", "set.0.value", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHelmReleaseConfig_OCI_login_with_set(resource, ns, name, repo, version, username, password string, replicaCount int) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+			name        = %q
+			namespace   = %q
+			repository  = %q
+			version     = %q
+			chart       = "test-chart"
+
+			repository_username = %q
+			repository_password = %q
+
+			set = [
+				{
+					name  = "replicaCount"
+					value = %d
+				}
+			]
+		}
+	`, resource, name, ns, repo, version, username, password, replicaCount)
 }
 
 func TestAccResourceRelease_recomputeMetadata(t *testing.T) {

--- a/helm/testdata/oci_registry/auth2.htpasswd
+++ b/helm/testdata/oci_registry/auth2.htpasswd
@@ -1,0 +1,1 @@
+hashicorp2:$2y$05$sZTJkFOnQlPcDdACLGOvAOBHJWKgwL2oOz1kltKpZ503gZdHm3LaO


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

  ## Rollback Plan                                                                                                                            
                                                                                                                                              
  If a change needs to be reverted, we will publish an updated version of the library.                                                        
                                                                                                                                              
  ## Changes to Security Controls                           

  No. This PR restores correct handling of user-supplied registry credentials on the `helm_release` Update path and adds a test that exercises
   it; it does not introduce or modify access controls, encryption, or logging.                                                               
   
  ### Description                                                                                                                             
                                                            
  Fixes a regression introduced in the 3.0.0 plugin-framework rewrite where `helm_release.Update` passes `repository_username` /              
  `repository_password` from the prior **state** to `OCIRegistryLogin` instead of from the current **plan**.
                                                                                                                                              
  For registries that issue short-lived tokens (AWS Public ECR via `data.aws_ecrpublic_authorization_token`, Azure ACR, etc.), the            
  state-stored token has typically expired by the next `terraform apply`. The login call then fails with `401/403` even though the user's
  configuration already contains a fresh token — the fresh token simply never reaches the login call. Create, ModifyPlan, and the             
  `helm_template` data source were already reading from plan/config and were not affected.

  Changes:
  - `helm/resource_helm_release.go` — in `Update`, pass `plan.Repository` / `plan.Chart` / `plan.RepositoryUsername` /
  `plan.RepositoryPassword` to `OCIRegistryLogin` instead of the `state.*` equivalents. One-line behavioral fix, cherry-picked from #1687 with
   Kevin Frommelt as author.
  - `helm/resource_helm_release_test.go` — new acceptance test `TestAccResourceRelease_OCI_login_rotated_credentials` that reproduces the     
  regression end-to-end. It starts the existing Docker-based OCI registry with auth, applies a release with one set of credentials, swaps the 
  registry's htpasswd between steps to simulate token rotation, then applies an Update with the new credentials and a changed `set` value.
  Also adds a small `rotateOCIRegistryCredentials` helper (uses `docker cp`; the distribution registry re-reads htpasswd per request so no    
  restart is needed) and extends `setupOCIRegistry` to return the container name.
  - `helm/testdata/oci_registry/auth2.htpasswd` — new fixture (`hashicorp2:terraform2`, bcrypt) used by the rotation step of the test.
                                                                                                                                              
  Verified: without the Update-path fix the new test fails at Step 2 with an OCI login error; with the fix it passes. `go vet ./helm/...` and 
  `gofmt` are clean.                                                                                                                          
                                                                                                                                              
  ### Acceptance tests                                                                                                                        
  - [x] Have you added an acceptance test for the functionality being added?
                                                                                                                                              
  ### Release Note                                          

  ```release-note
  resource/helm_release: fix OCI registry login on update to use credentials from the current plan instead of the prior state, so rotated
  short-lived tokens (e.g. AWS Public ECR, Azure ACR) are honored on subsequent applies                                                       
   
  References                                                                                                                                  
                                                            
  - Supersedes #1687 (same one-line fix, authorship preserved via cherry-pick) and adds the acceptance test that PR was missing.              
  - Fixes #1660 (OCI registry login failure against Azure ACR since 3.0.0).
  - Fixes #1645 (OCI registry login 403 against AWS Public ECR with aws_ecrpublic_authorization_token).                                       
  - Original concurrency/dedup design for OCI login introduced in #848 (9d162fb7), on which the current code path is based.                   
                                                                                                                                              
  Community Note                                                                                                                              
                                                                                                                                              
  - Please vote on this issue by adding a 👍 https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/ to the    
  original issue to help the community and maintainers prioritize this request
  - If you are interested in working on this issue or have submitted a pull request, please leave a comment