### PR TITLE
fix: config_context and proxy_url ignored when config_path is not set

### DIFF
--- a/helm/kubeconfig.go
+++ b/helm/kubeconfig.go
@@ -135,16 +135,23 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		} else {
 			loader.Precedence = expandedPaths
 		}
+	}
 
-		// Check ConfigContext
-		if !kubernetesConfig.ConfigContext.IsNull() {
-			overrides.CurrentContext = kubernetesConfig.ConfigContext.ValueString()
+	// Context overrides apply regardless of whether an explicit config_path is set,
+	// so that users can switch context on the default kubeconfig without specifying a path.
+	if !kubernetesConfig.ConfigContext.IsNull() {
+		if v := kubernetesConfig.ConfigContext.ValueString(); v != "" {
+			overrides.CurrentContext = v
 		}
-		if !kubernetesConfig.ConfigContextAuthInfo.IsNull() {
-			overrides.Context.AuthInfo = kubernetesConfig.ConfigContextAuthInfo.ValueString()
+	}
+	if !kubernetesConfig.ConfigContextAuthInfo.IsNull() {
+		if v := kubernetesConfig.ConfigContextAuthInfo.ValueString(); v != "" {
+			overrides.Context.AuthInfo = v
 		}
-		if !kubernetesConfig.ConfigContextCluster.IsNull() {
-			overrides.Context.Cluster = kubernetesConfig.ConfigContextCluster.ValueString()
+	}
+	if !kubernetesConfig.ConfigContextCluster.IsNull() {
+		if v := kubernetesConfig.ConfigContextCluster.ValueString(); v != "" {
+			overrides.Context.Cluster = v
 		}
 	}
 
@@ -185,7 +192,9 @@ func (m *Meta) NewKubeConfig(ctx context.Context, namespace string) (*KubeConfig
 		overrides.AuthInfo.Token = kubernetesConfig.Token.ValueString()
 	}
 	if !kubernetesConfig.ProxyURL.IsNull() {
-		overrides.ClusterDefaults.ProxyURL = kubernetesConfig.ProxyURL.ValueString()
+		if v := kubernetesConfig.ProxyURL.ValueString(); v != "" {
+			overrides.ClusterInfo.ProxyURL = v
+		}
 	}
 
 	if kubernetesConfig.Exec != nil {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Two bugs in `NewKubeConfig` (`helm/kubeconfig.go`) cause `kubernetes` provider block settings to be silently ignored:

**1. `config_context`, `config_context_auth_info`, `config_context_cluster` only applied when `config_path` is also set.**

These three overrides were inside the `if len(configPaths) > 0` block, so setting `config_context` without an explicit `config_path` had no effect — the provider used whatever context was active in the default kubeconfig, ignoring the provider configuration entirely.

**2. `proxy_url` stored on `ClusterDefaults` instead of `ClusterInfo`.**

In client-go's merge order, `ClusterDefaults` has the lowest priority and can be overridden by the kubeconfig file's cluster entry. All other explicit provider overrides (`host`, `tls_server_name`, `insecure`, `cluster_ca_certificate`) correctly use `ClusterInfo`, which has highest priority. `proxy_url` was the only field that was inconsistent.

**Fix:** move the three context overrides outside the `configPaths` block so they are always applied, and change `proxy_url` to use `overrides.ClusterInfo.ProxyURL`.

Minimal reproduction:

```hcl
provider "helm" {
  kubernetes {
    config_context = "my-cluster"   # ignored without config_path
    proxy_url      = "http://proxy:3128"  # lowest priority, may be overridden by kubeconfig
  }
}
```

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

No acceptance test added — verifying proxy and context behaviour requires a live cluster reachable through a proxy, which is not available in the standard CI environment. Both fixes are targeted single-field changes with a clear root cause traced through the client-go merge logic.

### Release Note

```release-note
bug fix: `config_context`, `config_context_auth_info`, `config_context_cluster`, and `proxy_url` in the `kubernetes` provider block are now applied correctly even when `config_path` is not explicitly set
```

### References

No existing issue. Observed on v3.1.1 with `TF_LOG=DEBUG`.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment