### PR TITLE
fix(docs): exec block syntax

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -130,7 +130,7 @@ provider "helm" {
   kubernetes = {
     host                   = var.cluster_endpoint
     cluster_ca_certificate = base64decode(var.cluster_ca_cert)
-    exec = {
+    exec {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
       command     = "aws"
@@ -148,7 +148,7 @@ provider "helm" {
         token = data.google_client_config.provider.access_token
         cluster_ca_certificate = base64decode(
         data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,)
-        exec = {
+        exec {
             api_version = "client.authentication.k8s.io/v1beta1"
             command     = "gke-gcloud-auth-plugin"
         }


### PR DESCRIPTION
Docs currently container exec = {}, but the latest kubernetes terraform provider documentation shows it should be exec {}.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
