### PR TITLE
Fix helm_release values causing perpetual diffs due to line ending differences

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -238,6 +238,55 @@ func suppressKeyring() planmodifier.String {
 	return suppressKeyringPlanModifier{}
 }
 
+// normalizeLineEndingsListPlanModifier suppresses diffs caused by CRLF vs LF
+// line endings in values YAML strings. This is common when values files are
+// checked out on Windows (CRLF) but state was stored from Linux/Mac (LF).
+type normalizeLineEndingsListPlanModifier struct{}
+
+func (m normalizeLineEndingsListPlanModifier) Description(ctx context.Context) string {
+	return "Normalize line endings (CRLF -> LF) to prevent cross-platform diffs"
+}
+
+func (m normalizeLineEndingsListPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m normalizeLineEndingsListPlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() || req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	planElems := req.PlanValue.Elements()
+	stateElems := req.StateValue.Elements()
+
+	if len(planElems) != len(stateElems) {
+		return
+	}
+
+	equal := true
+	for i, planElem := range planElems {
+		planStr, ok1 := planElem.(types.String)
+		stateStr, ok2 := stateElems[i].(types.String)
+		if !ok1 || !ok2 {
+			return
+		}
+		normalizedPlan := strings.ReplaceAll(planStr.ValueString(), "\r\n", "\n")
+		normalizedState := strings.ReplaceAll(stateStr.ValueString(), "\r\n", "\n")
+		if normalizedPlan != normalizedState {
+			equal = false
+			break
+		}
+	}
+
+	if equal {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func normalizeLineEndingsList() planmodifier.List {
+	return normalizeLineEndingsListPlanModifier{}
+}
+
 func namespaceDefault() defaults.String {
 	return namespaceDefaultValue{}
 }
@@ -529,6 +578,9 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Optional:    true,
 				Description: "List of values in raw YAML format to pass to helm",
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					normalizeLineEndingsList(),
+				},
 			},
 			"verify": schema.BoolAttribute{
 				Optional:    true,


### PR DESCRIPTION
## Description

Fixes #543

When values YAML files have CRLF line endings (common on Windows) but state was stored with LF line endings (from Linux/Mac), Terraform detects spurious diffs and plans unnecessary changes.

## Solution

Added a list plan modifier (`normalizeLineEndingsList`) for the `values` attribute that normalizes CRLF (`\r\n`) line endings to LF (`\n`) before comparison. If the values are semantically identical (only differing in line endings), the plan is suppressed.

## How It Works

```go
// In the plan modifier:
normalizedPlan := strings.ReplaceAll(planStr.ValueString(), "\r\n", "\n")
normalizedState := strings.ReplaceAll(stateStr.ValueString(), "\r\n", "\n")
if normalizedPlan != normalizedState {
    equal = false
}
```

## Testing

- Verified compilation succeeds
- When values only differ by line endings, no plan changes are detected