### PR TITLE
Fix set_sensitive redaction for keys containing escaped dots (#737 && #1788)

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -1115,7 +1115,7 @@ func cloakSetValuesModel(config map[string]interface{}, state *HelmTemplateModel
 const sensitiveContentModelValue = "(sensitive value)"
 
 func cloakSetValueModel(values map[string]interface{}, valuePath string) {
-	pathKeys := strings.Split(valuePath, ".")
+	pathKeys := splitKeyPath(valuePath)
 	sensitiveKey := pathKeys[len(pathKeys)-1]
 	parentPathKeys := pathKeys[:len(pathKeys)-1]
 

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -705,7 +705,7 @@ func (r *HelmRelease) Configure(ctx context.Context, req resource.ConfigureReque
 const sensitiveContentValue = "(sensitive value)"
 
 func cloakSetValue(values map[string]interface{}, valuePath string) {
-	pathKeys := strings.Split(valuePath, ".")
+	pathKeys := splitKeyPath(valuePath)
 	sensitiveKey := pathKeys[len(pathKeys)-1]
 	parentPathKeys := pathKeys[:len(pathKeys)-1]
 	m := values

--- a/helm/strvals_helpers.go
+++ b/helm/strvals_helpers.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helm
+
+import "strings"
+
+// splitKeyPath splits a Helm-style value path into key segments,
+// respecting backslash-escaped dots (\.) as literal dots within a key.
+// This matches the escaping convention used by Helm's strvals package.
+//
+// Examples:
+//
+//	splitKeyPath("server.config")          => ["server", "config"]
+//	splitKeyPath("server.oidc\\.config")   => ["server", "oidc.config"]
+//	splitKeyPath("a\\.b\\.c")              => ["a.b.c"]
+//	splitKeyPath("simple")                 => ["simple"]
+func splitKeyPath(path string) []string {
+	var segments []string
+	var current strings.Builder
+
+	i := 0
+	for i < len(path) {
+		if path[i] == '\\' && i+1 < len(path) && path[i+1] == '.' {
+			// Escaped dot: write literal dot, skip both characters
+			current.WriteByte('.')
+			i += 2
+		} else if path[i] == '.' {
+			// Unescaped dot: segment boundary
+			segments = append(segments, current.String())
+			current.Reset()
+			i++
+		} else {
+			current.WriteByte(path[i])
+			i++
+		}
+	}
+	segments = append(segments, current.String())
+
+	return segments
+}

--- a/helm/strvals_helpers_test.go
+++ b/helm/strvals_helpers_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitKeyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple single key",
+			input:    "simple",
+			expected: []string{"simple"},
+		},
+		{
+			name:     "dotted path",
+			input:    "a.b.c",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "single escaped dot",
+			input:    `a\.b`,
+			expected: []string{"a.b"},
+		},
+		{
+			name:     "mixed escaped and unescaped dots",
+			input:    `server.config.oidc\.config`,
+			expected: []string{"server", "config", "oidc.config"},
+		},
+		{
+			name:     "all dots escaped",
+			input:    `a\.b\.c`,
+			expected: []string{"a.b.c"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{""},
+		},
+		{
+			name:     "trailing dot",
+			input:    "a.",
+			expected: []string{"a", ""},
+		},
+		{
+			name:     "leading dot",
+			input:    ".a",
+			expected: []string{"", "a"},
+		},
+		{
+			name:     "multiple escaped dots no unescaped",
+			input:    `no\.dots\.here`,
+			expected: []string{"no.dots.here"},
+		},
+		{
+			name:     "backslash not before dot",
+			input:    `a\b.c`,
+			expected: []string{`a\b`, "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitKeyPath(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("splitKeyPath(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCloakSetValue_EscapedDot(t *testing.T) {
+	values := map[string]interface{}{
+		"server": map[string]interface{}{
+			"config": map[string]interface{}{
+				"oidc.config": "my-secret",
+			},
+		},
+	}
+
+	cloakSetValue(values, `server.config.oidc\.config`)
+
+	got := values["server"].(map[string]interface{})["config"].(map[string]interface{})["oidc.config"]
+	if got != sensitiveContentValue {
+		t.Errorf("expected %q, got %q", sensitiveContentValue, got)
+	}
+}
+
+func TestCloakSetValue_NormalDottedPath(t *testing.T) {
+	values := map[string]interface{}{
+		"auth": map[string]interface{}{
+			"password": "secret123",
+		},
+	}
+
+	cloakSetValue(values, "auth.password")
+
+	got := values["auth"].(map[string]interface{})["password"]
+	if got != sensitiveContentValue {
+		t.Errorf("expected %q, got %q", sensitiveContentValue, got)
+	}
+}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This is a bug fix that corrects existing sensitive value redaction to work with escaped dot characters in key names.

### Description
When using set_sensitive with key names containing literal dots (escaped with `\\.` in HCL, e.g., `server.config.oidc\.config`) the cloaking logic fails to redact the value in metadata output. The root cause is that `cloakSetValue()` and `cloakSetValueModel()` use `strings.Split(valuePath, ".")` which splits on all dots, including escaped ones. This means the function can't traverse the map to the correct key, and the sensitive value leaks in plaintext.                                                                           

The fix introduces a `splitKeyPath()` helper that tokenizes the path while respecting `\.` escape sequences, matching the behavior of Helm's `strvals` package which correctly handles escapes when setting values.  

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
```release-note
Fix `set_sensitive` redaction for keys containing escaped dots (`\.`)
```
### References
  - #737                                                                                              
  - #746             
  - #1221 
  - #1788

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
