### PR TITLE
Use OpenAPI v3 to build the GVK parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/terraform-provider-helm
 go 1.25.8
 
 require (
+	github.com/google/gnostic-models v0.6.9
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.16.0
@@ -14,6 +15,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
+	google.golang.org/protobuf v1.36.10
 	helm.sh/helm/v3 v3.18.5
 	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
@@ -75,7 +77,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -166,7 +167,6 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/helm/kube_resources.go
+++ b/helm/kube_resources.go
@@ -11,10 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	openapi_v3 "github.com/google/gnostic-models/openapiv3"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pkg/errors"
+	gproto "google.golang.org/protobuf/proto"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/release"
@@ -29,10 +32,12 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
-	"k8s.io/kube-openapi/pkg/util/proto"
+	"k8s.io/client-go/openapi"
+	kubeproto "k8s.io/kube-openapi/pkg/util/proto"
 	"k8s.io/kubectl/pkg/cmd/diff"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 // getKubeClient returns the underlying *kube.Client from an action.Configuration.
@@ -44,26 +49,117 @@ func getKubeClient(actionConfig *action.Configuration) (*kube.Client, error) {
 	return kc, nil
 }
 
-// regenerateGVKParser builds the parser from the raw OpenAPI schema.
-func regenerateGVKParser(dc discovery.DiscoveryInterface) (*managedfields.GvkParser, error) {
-	doc, err := dc.OpenAPISchema()
+// gvkParser provides per-GroupVersion field-set parsers built lazily from
+// the cluster's OpenAPI v3 schema.
+type gvkParser struct {
+	mu      sync.Mutex
+	paths   map[string]openapi.GroupVersion
+	parsers map[schema.GroupVersion]*managedfields.GvkParser
+}
+
+// newGVKParser builds a lazy per-GroupVersion parser cache from the cluster's
+// OpenAPI v3 discovery client.
+func newGVKParser(dc discovery.DiscoveryInterface) (*gvkParser, error) {
+	paths, err := dc.OpenAPIV3().Paths()
 	if err != nil {
 		return nil, err
 	}
+	return &gvkParser{
+		paths:   paths,
+		parsers: map[schema.GroupVersion]*managedfields.GvkParser{},
+	}, nil
+}
 
-	models, err := proto.NewOpenAPIData(doc)
-	if err != nil {
-		return nil, err
+func gvToAPIPath(gv schema.GroupVersion) string {
+	if gv.Group == "" {
+		return fmt.Sprintf("api/%s", gv.Version)
+	}
+	return fmt.Sprintf("apis/%s/%s", gv.Group, gv.Version)
+}
+
+// Type returns the parseable type for the given GVK, building the underlying
+// per-GroupVersion parser on first use.
+func (p *gvkParser) Type(gvk schema.GroupVersionKind) (*typed.ParseableType, error) {
+	gv := gvk.GroupVersion()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	parser, ok := p.parsers[gv]
+	if !ok {
+		path := gvToAPIPath(gv)
+		gvc, ok := p.paths[path]
+		if !ok {
+			return nil, fmt.Errorf("no OpenAPI v3 schema for GroupVersion %q", gv.String())
+		}
+		bs, err := gvc.Schema(openapi.ContentTypeOpenAPIV3PB)
+		if err != nil {
+			return nil, fmt.Errorf("fetch OpenAPI v3 schema for %q: %w", gv.String(), err)
+		}
+		var doc openapi_v3.Document
+		if err := gproto.Unmarshal(bs, &doc); err != nil {
+			return nil, fmt.Errorf("unmarshal OpenAPI v3 schema for %q: %w", gv.String(), err)
+		}
+		models, err := kubeproto.NewOpenAPIV3Data(&doc)
+		if err != nil {
+			return nil, err
+		}
+		normalizeV3Extensions(models)
+		parser, err = managedfields.NewGVKParser(models, false)
+		if err != nil {
+			return nil, fmt.Errorf("build GVK parser for %q: %w", gv.String(), err)
+		}
+		p.parsers[gv] = parser
 	}
 
-	return managedfields.NewGVKParser(models, false)
+	pt := parser.Type(gvk)
+	if pt == nil {
+		return nil, fmt.Errorf("no parseable type found for %s", gvk.String())
+	}
+	return pt, nil
+}
+
+// normalizeV3Extensions rewrites every model's vendor extensions so that
+// managedfields.NewGVKParser (and the schemaconv it uses) can read them.
+func normalizeV3Extensions(models kubeproto.Models) {
+	for _, name := range models.ListModels() {
+		m := models.LookupModel(name)
+		if m == nil {
+			continue
+		}
+		ext := m.GetExtensions()
+		for k, v := range ext {
+			ext[k] = toInterfaceKeyedMap(v)
+		}
+	}
+}
+
+// toInterfaceKeyedMap recursively converts map[string]interface{} values
+// (yaml.v3 shape) to map[interface{}]interface{} (yaml.v2 shape), descending
+// into nested maps and slices.
+func toInterfaceKeyedMap(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		out := make(map[interface{}]interface{}, len(t))
+		for k, vv := range t {
+			out[k] = toInterfaceKeyedMap(vv)
+		}
+		return out
+	case []interface{}:
+		for i, vv := range t {
+			t[i] = toInterfaceKeyedMap(vv)
+		}
+		return t
+	default:
+		return v
+	}
 }
 
 // removeUnmanagedFields strips fields managed by kube-controller-manager or subresources.
-func removeUnmanagedFields(parser *managedfields.GvkParser, obj runtime.Object, gvk schema.GroupVersionKind) error {
-	parseableType := parser.Type(gvk)
-	if parseableType == nil {
-		return errors.Errorf("no parseable type found for %s", gvk.String())
+func removeUnmanagedFields(parser *gvkParser, obj runtime.Object, gvk schema.GroupVersionKind) error {
+	parseableType, err := parser.Type(gvk)
+	if err != nil {
+		return err
 	}
 	typedObj, err := parseableType.FromStructured(obj)
 	if err != nil {
@@ -101,7 +197,7 @@ func mapRuntimeObjects(ctx context.Context, kc *kube.Client, objects []runtime.O
 		diags.AddError("Client Error", err.Error())
 		return nil, diags
 	}
-	parser, err := regenerateGVKParser(clientSet.Discovery())
+	parser, err := newGVKParser(clientSet.Discovery())
 	if err != nil {
 		diags.AddError("Parser Error", err.Error())
 		return nil, diags

--- a/helm/kube_resources_test.go
+++ b/helm/kube_resources_test.go
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package helm
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGVToAPIPath(t *testing.T) {
+	tests := []struct {
+		name string
+		gv   schema.GroupVersion
+		want string
+	}{
+		{
+			name: "core group uses /api",
+			gv:   schema.GroupVersion{Group: "", Version: "v1"},
+			want: "api/v1",
+		},
+		{
+			name: "named group uses /apis",
+			gv:   schema.GroupVersion{Group: "apps", Version: "v1"},
+			want: "apis/apps/v1",
+		},
+		{
+			name: "dotted group",
+			gv:   schema.GroupVersion{Group: "cert-manager.io", Version: "v1"},
+			want: "apis/cert-manager.io/v1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, gvToAPIPath(tc.gv))
+		})
+	}
+}
+
+func TestToInterfaceKeyedMap(t *testing.T) {
+	t.Run("scalars are returned unchanged", func(t *testing.T) {
+		for _, v := range []interface{}{"x", 1, 1.5, true, nil} {
+			assert.Equal(t, v, toInterfaceKeyedMap(v))
+		}
+	})
+
+	t.Run("string-keyed map is converted to interface-keyed map", func(t *testing.T) {
+		in := map[string]interface{}{"a": "b"}
+		out := toInterfaceKeyedMap(in)
+		want := map[interface{}]interface{}{"a": "b"}
+		assert.Equal(t, want, out)
+	})
+
+	t.Run("nested maps are converted recursively", func(t *testing.T) {
+		in := map[string]interface{}{
+			"outer": map[string]interface{}{
+				"inner": map[string]interface{}{"k": "v"},
+			},
+		}
+		out := toInterfaceKeyedMap(in)
+		want := map[interface{}]interface{}{
+			"outer": map[interface{}]interface{}{
+				"inner": map[interface{}]interface{}{"k": "v"},
+			},
+		}
+		assert.Equal(t, want, out)
+	})
+
+	t.Run("maps inside slices are converted", func(t *testing.T) {
+		in := []interface{}{
+			map[string]interface{}{"group": "", "version": "v1", "kind": "Pod"},
+			map[string]interface{}{"group": "apps", "version": "v1", "kind": "Deployment"},
+		}
+		out := toInterfaceKeyedMap(in)
+		want := []interface{}{
+			map[interface{}]interface{}{"group": "", "version": "v1", "kind": "Pod"},
+			map[interface{}]interface{}{"group": "apps", "version": "v1", "kind": "Deployment"},
+		}
+		assert.Equal(t, want, out)
+	})
+
+	t.Run("already interface-keyed map is returned unchanged", func(t *testing.T) {
+		in := map[interface{}]interface{}{"a": "b"}
+		out := toInterfaceKeyedMap(in)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("slice is mutated in place and returned", func(t *testing.T) {
+		in := []interface{}{map[string]interface{}{"a": "b"}}
+		out := toInterfaceKeyedMap(in)
+		// same backing slice
+		assert.True(t, reflect.ValueOf(in).Pointer() == reflect.ValueOf(out).Pointer())
+		// element was converted
+		assert.Equal(t, map[interface{}]interface{}{"a": "b"}, in[0])
+	})
+}


### PR DESCRIPTION

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description

The manifest experiment uses `managedfields.NewGVKParser` to strip controller-managed fields from live cluster objects when computing the plan diff. The parser was built from the merged OpenAPI v2 document returned by `discovery.OpenAPISchema()`.

On clusters where the aggregated v2 swagger contains duplicate GVK entries (commonly triggered by certain CRDs such as cert-manager on Kubernetes 1.28+), `NewGVKParser` fails with errors like:

```
duplicate entry for /v1, Kind=APIResourceList
```

This makes `terraform plan` unusable for any helm_release on affected clusters when `experiments { manifest = true }` is set.

Switch to OpenAPI v3, which is served per-GroupVersion and so this collision can't happen. The new `gvkParser` type wraps the v3 discovery client and builds (and caches) a `managedfields.GvkParser` lazily per GroupVersion as GVKs are encountered.

`proto.NewOpenAPIV3Data` decodes vendor extensions via 
`gopkg.in/yaml.v3`, which produces nested maps as 
`map[string]interface{}`. The v2 path uses `yaml.v2` and produces 
`map[interface{}]interface{}`. Several consumers in
`k8s.io/kube-openapi/pkg/schemaconv` and 
`k8s.io/apimachinery/pkg/util/managedfields`
type-assert extension values to the v2 shape (eg the GVK list in
`x-kubernetes-group-version-kind`, items in `x-kubernetes-unions` and 
their `fields-to-discriminateBy`) and either silently skip or return an
error when they encounter v3-derived models.

This means we need to deep-convert every `map[string]interface{}` 
inside every extension to `map[interface{}]interface{}` so both shapes
look identical to those consumers.

This can be removed once upstream accepts both shapes but that probably 
requires extensive refactoring which I've tried to avoid here for now.

See the following related issues and pull requests across the Kubernetes ecosystem:

- Kubernetes:
  - https://github.com/kubernetes/kubernetes/issues/103597
  - https://github.com/kubernetes/kubernetes/issues/109275
    - Fixed by pruning defaults for CRDs OpenAPI v2
    - https://github.com/kubernetes/kubernetes/pull/110179
  - https://github.com/kubernetes/kubernetes/issues/128201
- pingcap/tidb-operator:
  - Fixed by bumping to OpenAPI v3
  - https://github.com/pingcap/tidb-operator/pull/6056

Fixes https://github.com/hashicorp/terraform-provider-helm/issues/1717


### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

I've added some basic unit tests around the two new functions but ultimately this probably needs some kind of integration test that would have caught this issue originally. I'm not sure the best way to introduce that here though and what the maintainers think?

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix `experiments.manifest = true`
```
### References

- https://github.com/pingcap/tidb-operator/pull/6056

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
