### PR TITLE
linux/s390x build added

### DIFF
--- a/.changelog/1800.txt
+++ b/.changelog/1800.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added linux/s390x build target for IBM Z platform
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,18 +95,24 @@ jobs:
       fail-fast: true
       matrix:
         goos: [freebsd, windows, linux, darwin]
-        goarch: ["386", "amd64", "arm", "arm64"]
+        goarch: ["386", "amd64", "arm", "arm64", "s390x"]
         exclude:
           - goos: freebsd
             goarch: arm64
+          - goos: freebsd
+            goarch: s390x
           - goos: windows
             goarch: arm64
           - goos: windows
             goarch: arm
+          - goos: windows
+            goarch: s390x
           - goos: darwin
             goarch: 386
           - goos: darwin
             goarch: arm
+          - goos: darwin
+            goarch: s390x
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:

--- a/.release/terraform-provider-kubernetes-artifacts.hcl
+++ b/.release/terraform-provider-kubernetes-artifacts.hcl
@@ -10,6 +10,7 @@ artifacts {
     "terraform-provider-helm_${version}_linux_amd64.zip",
     "terraform-provider-helm_${version}_linux_arm.zip",
     "terraform-provider-helm_${version}_linux_arm64.zip",
+    "terraform-provider-helm_${version}_linux_s390x.zip",
     "terraform-provider-helm_${version}_windows_386.zip",
     "terraform-provider-helm_${version}_windows_amd64.zip",
   ]


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

<!--- Please leave a helpful description of the pull request here. --->
- Add linux/s390x build target for IBM Z platform support
- Add s390x to the goarch build matrix in .github/workflows/build.yml with exclusions for freebsd, windows, and darwin
- Add linux_s390x.zip artifact entry to the CRT release manifest

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added linux/s390x build target for IBM Z platform
```
