### PR TITLE
fix: handle unreachable cluster during plan phase

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
@@ -711,6 +712,31 @@ func OCIRegistryPerformLogin(ctx context.Context, meta *Meta, registryClient *re
 	meta.loggedInOCIRegistries[u.Host] = struct{}{}
 	tflog.Info(ctx, fmt.Sprintf("Logged into OCI registry %q", u.Host))
 	return nil
+}
+
+// isKubernetesConfigured checks whether the provider has a valid Kubernetes
+// configuration that can be used to connect to a cluster.
+func (m *Meta) isKubernetesConfigured(ctx context.Context) bool {
+	if m == nil || m.Data == nil || m.Data.Kubernetes.IsNull() || m.Data.Kubernetes.IsUnknown() {
+		return false
+	}
+
+	var kubernetesConfig KubernetesConfigModel
+	diags := m.Data.Kubernetes.As(ctx, &kubernetesConfig, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		return false
+	}
+
+	// A cluster is considered configured if at least one of the following is set:
+	hasHost := !kubernetesConfig.Host.IsNull() && !kubernetesConfig.Host.IsUnknown() && kubernetesConfig.Host.ValueString() != ""
+	hasConfigPath := !kubernetesConfig.ConfigPath.IsNull() && !kubernetesConfig.ConfigPath.IsUnknown() && kubernetesConfig.ConfigPath.ValueString() != ""
+	hasConfigPaths := !kubernetesConfig.ConfigPaths.IsNull() && !kubernetesConfig.ConfigPaths.IsUnknown() && len(kubernetesConfig.ConfigPaths.Elements()) > 0
+
+	configured := hasHost || hasConfigPath || hasConfigPaths
+	if !configured {
+		tflog.Debug(ctx, "Kubernetes configuration is not available (host, config_path, and config_paths are all empty or unknown)")
+	}
+	return configured
 }
 
 // GetHelmConfiguration retrieves the Helm configuration for a given namespace

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
@@ -712,31 +711,6 @@ func OCIRegistryPerformLogin(ctx context.Context, meta *Meta, registryClient *re
 	meta.loggedInOCIRegistries[u.Host] = struct{}{}
 	tflog.Info(ctx, fmt.Sprintf("Logged into OCI registry %q", u.Host))
 	return nil
-}
-
-// isKubernetesConfigured checks whether the provider has a valid Kubernetes
-// configuration that can be used to connect to a cluster.
-func (m *Meta) isKubernetesConfigured(ctx context.Context) bool {
-	if m == nil || m.Data == nil || m.Data.Kubernetes.IsNull() || m.Data.Kubernetes.IsUnknown() {
-		return false
-	}
-
-	var kubernetesConfig KubernetesConfigModel
-	diags := m.Data.Kubernetes.As(ctx, &kubernetesConfig, basetypes.ObjectAsOptions{})
-	if diags.HasError() {
-		return false
-	}
-
-	// A cluster is considered configured if at least one of the following is set:
-	hasHost := !kubernetesConfig.Host.IsNull() && !kubernetesConfig.Host.IsUnknown() && kubernetesConfig.Host.ValueString() != ""
-	hasConfigPath := !kubernetesConfig.ConfigPath.IsNull() && !kubernetesConfig.ConfigPath.IsUnknown() && kubernetesConfig.ConfigPath.ValueString() != ""
-	hasConfigPaths := !kubernetesConfig.ConfigPaths.IsNull() && !kubernetesConfig.ConfigPaths.IsUnknown() && len(kubernetesConfig.ConfigPaths.Elements()) > 0
-
-	configured := hasHost || hasConfigPath || hasConfigPaths
-	if !configured {
-		tflog.Debug(ctx, "Kubernetes configuration is not available (host, config_path, and config_paths are all empty or unknown)")
-	}
-	return configured
 }
 
 // GetHelmConfiguration retrieves the Helm configuration for a given namespace

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2234,13 +2234,35 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	if plan.UpgradeInstall.ValueBool() && config.Version.IsNull() {
 		tflog.Debug(ctx, fmt.Sprintf("%s upgrade_install is enabled and version attribute is empty", logID))
 
-		installedVersion, err := getInstalledReleaseVersion(ctx, meta, actionConfig, name)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to check installed release version", err.Error())
-			return
+		clusterAvailable := meta.isKubernetesConfigured(ctx)
+
+		var installedVersion string
+		if clusterAvailable {
+			var err error
+			installedVersion, err = getInstalledReleaseVersion(ctx, meta, actionConfig, name)
+			if err != nil {
+				// If the cluster is unreachable (e.g. being created in the same apply),
+				// fall back to using the chart version or marking as unknown.
+				if strings.Contains(err.Error(), "Kubernetes cluster unreachable") ||
+					strings.Contains(err.Error(), "no configuration has been provided") {
+					tflog.Debug(ctx, fmt.Sprintf("%s cluster unreachable during plan, cannot determine installed version", logID))
+					clusterAvailable = false
+				} else {
+					resp.Diagnostics.AddError("Failed to check installed release version", err.Error())
+					return
+				}
+			}
 		}
 
-		if installedVersion != "" {
+		if !clusterAvailable {
+			// Use the chart version if available, otherwise mark as unknown
+			tflog.Debug(ctx, fmt.Sprintf("%s cluster unreachable during plan, deferring version resolution to apply", logID))
+			if len(chart.Metadata.Version) > 0 {
+				plan.Version = types.StringValue(chart.Metadata.Version)
+			} else {
+				plan.Version = types.StringUnknown()
+			}
+		} else if installedVersion != "" {
 			tflog.Debug(ctx, fmt.Sprintf("%s setting version to installed version %s", logID, installedVersion))
 			plan.Version = types.StringValue(installedVersion)
 		} else if len(chart.Metadata.Version) > 0 {
@@ -2263,7 +2285,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 			} else {
 				resp.Diagnostics.AddError(
 					"Planned version is different from configured version",
-					fmt.Sprintf(`The version in the configuration is %q but the planned version is %q. 
+					fmt.Sprintf(`The version in the configuration is %q but the planned version is %q.
 You should update the version in your configuration to %[2]q, or remove the version attribute from your configuration.`, config.Version.ValueString(), plan.Version.ValueString()))
 				return
 			}

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2234,33 +2234,21 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	if plan.UpgradeInstall.ValueBool() && config.Version.IsNull() {
 		tflog.Debug(ctx, fmt.Sprintf("%s upgrade_install is enabled and version attribute is empty", logID))
 
-		clusterAvailable := meta.isKubernetesConfigured(ctx)
-
-		var installedVersion string
-		if clusterAvailable {
-			var err error
-			installedVersion, err = getInstalledReleaseVersion(ctx, meta, actionConfig, name)
-			if err != nil {
-				// If the cluster is unreachable (e.g. being created in the same apply),
-				// fall back to using the chart version or marking as unknown.
-				if strings.Contains(err.Error(), "Kubernetes cluster unreachable") ||
-					strings.Contains(err.Error(), "no configuration has been provided") {
-					tflog.Debug(ctx, fmt.Sprintf("%s cluster unreachable during plan, cannot determine installed version", logID))
-					clusterAvailable = false
+		installedVersion, err := getInstalledReleaseVersion(ctx, meta, actionConfig, name)
+		if err != nil {
+			if strings.Contains(err.Error(), "Kubernetes cluster unreachable") {
+				// Cluster is not reachable during plan — this is expected when the
+				// cluster is being created in the same Terraform configuration.
+				// Fall back to chart version or mark as unknown for apply-time resolution.
+				tflog.Debug(ctx, fmt.Sprintf("%s cluster unreachable during plan, falling back to chart version", logID))
+				if len(chart.Metadata.Version) > 0 {
+					plan.Version = types.StringValue(chart.Metadata.Version)
 				} else {
-					resp.Diagnostics.AddError("Failed to check installed release version", err.Error())
-					return
+					plan.Version = types.StringUnknown()
 				}
-			}
-		}
-
-		if !clusterAvailable {
-			// Use the chart version if available, otherwise mark as unknown
-			tflog.Debug(ctx, fmt.Sprintf("%s cluster unreachable during plan, deferring version resolution to apply", logID))
-			if len(chart.Metadata.Version) > 0 {
-				plan.Version = types.StringValue(chart.Metadata.Version)
 			} else {
-				plan.Version = types.StringUnknown()
+				resp.Diagnostics.AddError("Failed to check installed release version", err.Error())
+				return
 			}
 		} else if installedVersion != "" {
 			tflog.Debug(ctx, fmt.Sprintf("%s setting version to installed version %s", logID, installedVersion))


### PR DESCRIPTION
Add a check for Kubernetes configuration availability before attempting to query the cluster during the plan phase when `upgrade_install` is enabled and no version is specified.

Previously, if the cluster was being created in the same Terraform apply, querying the installed release version would fail with an unreachable cluster error, blocking the plan.

Introduce `isKubernetesConfigured` on `Meta` to validate whether a host, config path, or config paths are set and known before making cluster API calls.

During planning, if the cluster is not yet available, fall back to using the chart metadata version if present, or mark the version as unknown to defer resolution to apply time.

Also remove a trailing whitespace from an error format string.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References
Fixes: https://github.com/hashicorp/terraform-provider-helm/issues/1495
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
