### PR TITLE
docs: Mention support of type literal for set

### DIFF
--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -290,7 +290,7 @@ The `set`, `set_list`, and `set_sensitive` blocks support:
 
 * `name` - (Required) full name of the variable to be set.
 * `value` - (Required; Optional for `set`) value of the variable to be set.
-* `type` - (Optional) type of the variable to be set. Valid options are `auto` and `string`.
+* `type` - (Optional) type of the variable to be set. Valid options are `auto`, `string` and `literal`.
 
 Since Terraform Utilizes HCL as well as Helm using the Helm Template Language, it's necessary to escape the `{}`, `[]`, `.`, and `,` characters twice in order for it to be parsed. `name` should also be set to the `value path`, and `value` is the desired value that will be set.
 


### PR DESCRIPTION
Type literal (`--set-literal`) is supported for `set` since v3.0.0.

### References

- https://github.com/hashicorp/terraform-provider-helm/pull/1615

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
