### PR TITLE
Fix #1571: Change max_history default from 0 to 10

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -129,7 +129,7 @@ var defaultAttributes = map[string]interface{}{
 	"disable_webhooks":           false,
 	"force_update":               false,
 	"lint":                       false,
-	"max_history":                int64(0),
+	"max_history":                int64(10),
 	"pass_credentials":           false,
 	"recreate_pods":              false,
 	"render_subchart_notes":      true,

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -188,7 +188,7 @@ func TestAccResourceRelease_import(t *testing.T) {
 					resource.TestCheckResourceAttr("helm_release.imported", "reset_values", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "reuse_values", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "recreate_pods", "false"),
-					resource.TestCheckResourceAttr("helm_release.imported", "max_history", "0"),
+					resource.TestCheckResourceAttr("helm_release.imported", "max_history", "10"),
 					resource.TestCheckResourceAttr("helm_release.imported", "skip_crds", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "cleanup_on_fail", "false"),
 					resource.TestCheckResourceAttr("helm_release.imported", "dependency_update", "false"),


### PR DESCRIPTION
### Description
Changes the default value of `max_history` from 0 (unbounded) to 10, providing a safer default that prevents unbounded growth of Helm release history.

### Release Note
`max_history` default changed from 0 to 10

### Acceptance Tests
- [ ] Acceptance tests passed