### PR TITLE
Fix #1709: registry_config_path argument ignored

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -605,7 +605,7 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		},
 		loggedInOCIRegistries: make(map[string]struct{}),
 	}
-	registryClient, err := registry.NewClient()
+	registryClient, err := registry.NewClient(registry.ClientOptCredentialsFile(settings.RegistryConfig))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Registry client initialization failed",


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The `registry_config_path` provider argument was correctly read from config and set on Helm CLI settings, but was never passed to `registry.NewClient()`. This meant the custom registry config path was silently ignored and the default path was always used.

This one-line fix passes `registry.ClientOptCredentialsFile(settings.RegistryConfig)` to `registry.NewClient()`, ensuring the configured `registry_config_path` is actually used.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

### Release Note

```release-note
bug: Fix `registry_config_path` provider argument being ignored
```

### References

Fixes #1709
