### PR TITLE
Fix #1740: Strip v prefix from version for OCI chart references

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -886,6 +886,9 @@ func chartPathOptionsModel(model *HelmTemplateModel, meta *Meta, cpo *action.Cha
 	}
 
 	version := getVersionModel(model)
+	if registry.IsOCI(repository) {
+		version = strings.TrimPrefix(version, "v")
+	}
 
 	cpo.CaFile = model.RepositoryCaFile.ValueString()
 	cpo.CertFile = model.RepositoryCertFile.ValueString()

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1323,6 +1323,9 @@ func chartPathOptions(model *HelmReleaseModel, meta *Meta, cpo *action.ChartPath
 	}
 
 	version := getVersion(model)
+	if registry.IsOCI(repository) {
+		version = strings.TrimPrefix(version, "v")
+	}
 
 	cpo.CaFile = model.RepositoryCaFile.ValueString()
 	cpo.CertFile = model.RepositoryCertFile.ValueString()


### PR DESCRIPTION
When using OCI-based Helm charts, version strings with a `v` prefix (e.g. `v4.14.1`) cause "not found" errors because OCI registries store tags without the `v` prefix.

This change strips the `v` prefix from the version string when the repository is an OCI registry, matching the existing convention used by `versionsEqual()`.

Applies to both `helm_release` resource and `helm_template` data source.