### PR TITLE
Fix #1287, #1221: Mark values and metadata as sensitive to prevent sensitive data leakage in plan output

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -403,6 +403,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 					},
 					"values": schema.StringAttribute{
 						Computed:    true,
+						Sensitive:   true,
 						Description: "Set of extra values. added to the chart. The sensitive data is cloaked. JSON encoded.",
 					},
 					"version": schema.StringAttribute{
@@ -527,6 +528,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			}),
 			"values": schema.ListAttribute{
 				Optional:    true,
+				Sensitive:   true,
 				Description: "List of values in raw YAML format to pass to helm",
 				ElementType: types.StringType,
 			},


### PR DESCRIPTION
## Description

Fixes #1287 - the provider displays sensitive values in plain text in the `metadata` block during terraform plan/apply/destroy. The `metadata.values` field stores the full rendered values as a JSON string and Terraform treats it as regular text.

Also fixes #1221 (helm_release does not respect `sensitive` attribute) since both share the same root cause.

## Changes

- Marked `metadata.values` sub-attribute as `Sensitive: true` in the schema
- Marked the top-level `values` attribute as `Sensitive: true` in the schema

These changes prevent Terraform from displaying the full values content in plan output during destroy or update in-place operations.