### PR TITLE
Add 'json' type for set blocks in helm_release and helm_template (#1678)

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -302,7 +302,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 							Optional: true,
 							Computed: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -338,7 +338,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 						"type": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -358,7 +358,7 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 						"type": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string"),
+								stringvalidator.OneOf("auto", "string", "json"),
 							},
 						},
 					},
@@ -991,6 +991,13 @@ func applySetValue(base map[string]interface{}, set SetValue) diag.Diagnostics {
 		} else {
 			base[name] = literal
 		}
+	case "json":
+		var parsedValue interface{}
+		if err := json.Unmarshal([]byte(value), &parsedValue); err != nil {
+			diags.AddError("Failed parsing JSON value", fmt.Sprintf("Key %q with JSON value %s: %s", name, value, err))
+			return diags
+		}
+		base[name] = parsedValue
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type: %s", valueType))
 	}
@@ -1045,6 +1052,13 @@ func applySetSensitiveValue(base map[string]interface{}, setSensitive SetSensiti
 		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
 			diags.AddError("Failed parsing sensitive string value", fmt.Sprintf("Failed parsing key %q with value %s: %s", name, value, err))
 		}
+	case "json":
+		var parsedValue interface{}
+		if err := json.Unmarshal([]byte(value), &parsedValue); err != nil {
+			diags.AddError("Failed parsing sensitive JSON value", fmt.Sprintf("Key %q with JSON value %s: %s", name, value, err))
+			return diags
+		}
+		base[name] = parsedValue
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type for sensitive value: %s", valueType))
 	}

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -569,7 +569,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Computed: true,
 							Default:  stringdefault.StaticString(""),
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -593,7 +593,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Optional:  true,
 							WriteOnly: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string"),
+								stringvalidator.OneOf("auto", "string", "json"),
 							},
 						},
 					},
@@ -636,7 +636,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 						"type": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("auto", "string", "literal"),
+								stringvalidator.OneOf("auto", "string", "literal", "json"),
 							},
 						},
 					},
@@ -1567,6 +1567,13 @@ func getValue(base map[string]interface{}, set setResourceModel) diag.Diagnostic
 		} else {
 			base[name] = literal
 		}
+	case "json":
+		var parsedValue interface{}
+		if err := json.Unmarshal([]byte(value), &parsedValue); err != nil {
+			diags.AddError("Failed parsing JSON value", fmt.Sprintf("Key %q with JSON value %s: %s", name, value, err))
+			return diags
+		}
+		base[name] = parsedValue
 	default:
 		diags.AddError("Unexpected type", fmt.Sprintf("Unexpected type: %s", valueType))
 		return diags


### PR DESCRIPTION
## Description

Adds a new `type = "json"` option for `set` blocks in `helm_release` and `helm_template`. Previously only `"auto"`, `"string"`, and `"literal"` were supported.

The JSON type decodes the value as JSON (using `encoding/json.Unmarshal`) instead of YAML/auto-detection, which is useful for complex nested structures.

## Changes

- **helm/resource_helm_release.go**: Added `"json"` to all `stringvalidator.OneOf` validators for set block types, and added `case "json"` handling in `getValue()`
- **helm/data_helm_template.go**: Added `"json"` to all `stringvalidator.OneOf` validators for set block types, and added `case "json"` handling in `applySetValue()` and `applySetSensitiveValue()`

Closes #1678