### PR TITLE
Feat #1609: Add skip_schema_validation attribute

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -93,6 +93,7 @@ type HelmTemplateModel struct {
 	SetWO                    types.List       `tfsdk:"set_wo"`
 	ShowOnly                 types.List       `tfsdk:"show_only"`
 	SkipCrds                 types.Bool       `tfsdk:"skip_crds"`
+	SkipSchemaValidation     types.Bool       `tfsdk:"skip_schema_validation"`
 	SkipTests                types.Bool       `tfsdk:"skip_tests"`
 	Timeout                  types.Int64      `tfsdk:"timeout"`
 	Timeouts                 timeouts.Value   `tfsdk:"timeouts"`
@@ -373,6 +374,10 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 				Optional:    true,
 				Description: "If set, no CRDs will be installed. By default, CRDs are installed if not already present.",
 			},
+			"skip_schema_validation": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If set, the installation process will not validate the chart against the JSON schema of the chart",
+			},
 			"skip_tests": schema.BoolAttribute{
 				Optional:    true,
 				Description: "If set, tests will not be rendered. By default, tests are rendered.",
@@ -465,6 +470,9 @@ func (d *HelmTemplate) Read(ctx context.Context, req datasource.ReadRequest, res
 	}
 	if state.SkipTests.IsNull() || state.SkipTests.IsUnknown() {
 		state.SkipTests = types.BoolValue(false)
+	}
+	if state.SkipSchemaValidation.IsNull() || state.SkipSchemaValidation.IsUnknown() {
+		state.SkipSchemaValidation = types.BoolValue(false)
 	}
 	if state.RenderSubchartNotes.IsNull() || state.RenderSubchartNotes.IsUnknown() {
 		state.RenderSubchartNotes = types.BoolValue(false)
@@ -596,6 +604,7 @@ func (d *HelmTemplate) Read(ctx context.Context, req datasource.ReadRequest, res
 	client.DependencyUpdate = state.DependencyUpdate.ValueBool()
 	client.DisableHooks = state.DisableWebhooks.ValueBool()
 	client.DisableOpenAPIValidation = state.DisableOpenAPIValidation.ValueBool()
+	client.SkipSchemaValidation = state.SkipSchemaValidation.ValueBool()
 	client.Atomic = state.Atomic.ValueBool()
 	client.Replace = state.Replace.ValueBool()
 	client.SkipCRDs = state.SkipCrds.ValueBool()

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -107,6 +107,7 @@ type HelmReleaseModel struct {
 	SetList                  types.List       `tfsdk:"set_list"`
 	SetSensitive             types.List       `tfsdk:"set_sensitive"`
 	SkipCrds                 types.Bool       `tfsdk:"skip_crds"`
+	SkipSchemaValidation     types.Bool       `tfsdk:"skip_schema_validation"`
 	Status                   types.String     `tfsdk:"status"`
 	TakeOwnership            types.Bool       `tfsdk:"take_ownership"`
 	Timeout                  types.Int64      `tfsdk:"timeout"`
@@ -137,6 +138,7 @@ var defaultAttributes = map[string]interface{}{
 	"reset_values":               false,
 	"reuse_values":               false,
 	"skip_crds":                  false,
+	"skip_schema_validation":     false,
 	"take_ownership":             false,
 	"timeout":                    int64(300),
 	"verify":                     false,
@@ -503,6 +505,12 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Default:     booldefault.StaticBool(defaultAttributes["skip_crds"].(bool)),
 				Description: "If set, no CRDs will be installed. By default, CRDs are installed if not already present",
 			},
+			"skip_schema_validation": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(defaultAttributes["skip_schema_validation"].(bool)),
+				Description: "If set, the installation process will not validate the chart against the JSON schema of the chart",
+			},
 			"status": schema.StringAttribute{
 				Computed:    true,
 				Description: "Status of the release",
@@ -861,6 +869,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 	client.SkipCRDs = state.SkipCrds.ValueBool()
 	client.SubNotes = state.RenderSubchartNotes.ValueBool()
 	client.DisableOpenAPIValidation = state.DisableOpenapiValidation.ValueBool()
+	client.SkipSchemaValidation = state.SkipSchemaValidation.ValueBool()
 	client.Replace = state.Replace.ValueBool()
 	client.Description = state.Description.ValueString()
 	client.CreateNamespace = state.CreateNamespace.ValueBool()
@@ -903,6 +912,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 		upgradeClient.SkipCRDs = state.SkipCrds.ValueBool()
 		upgradeClient.SubNotes = state.RenderSubchartNotes.ValueBool()
 		upgradeClient.DisableOpenAPIValidation = state.DisableOpenapiValidation.ValueBool()
+		upgradeClient.SkipSchemaValidation = state.SkipSchemaValidation.ValueBool()
 		upgradeClient.Description = state.Description.ValueString()
 
 		if state.PostRender != nil {
@@ -1150,6 +1160,7 @@ func (r *HelmRelease) Update(ctx context.Context, req resource.UpdateRequest, re
 	client.SkipCRDs = plan.SkipCrds.ValueBool()
 	client.SubNotes = plan.RenderSubchartNotes.ValueBool()
 	client.DisableOpenAPIValidation = plan.DisableOpenapiValidation.ValueBool()
+	client.SkipSchemaValidation = plan.SkipSchemaValidation.ValueBool()
 	client.Force = plan.ForceUpdate.ValueBool()
 	client.ResetValues = plan.ResetValues.ValueBool()
 	client.ReuseValues = plan.ReuseValues.ValueBool()
@@ -2070,6 +2081,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 			install.SkipCRDs = plan.SkipCrds.ValueBool()
 			install.SubNotes = plan.RenderSubchartNotes.ValueBool()
 			install.DisableOpenAPIValidation = plan.DisableOpenapiValidation.ValueBool()
+			install.SkipSchemaValidation = plan.SkipSchemaValidation.ValueBool()
 			install.Replace = plan.Replace.ValueBool()
 			install.Description = plan.Description.ValueString()
 			install.CreateNamespace = plan.CreateNamespace.ValueBool()
@@ -2156,6 +2168,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		upgrade.Atomic = plan.Atomic.ValueBool()
 		upgrade.SubNotes = plan.RenderSubchartNotes.ValueBool()
 		upgrade.WaitForJobs = plan.WaitForJobs.ValueBool()
+		upgrade.SkipSchemaValidation = plan.SkipSchemaValidation.ValueBool()
 		upgrade.Force = plan.ForceUpdate.ValueBool()
 		upgrade.ResetValues = plan.ResetValues.ValueBool()
 		upgrade.ReuseValues = plan.ReuseValues.ValueBool()


### PR DESCRIPTION
Adds a `skip_schema_validation` boolean attribute to `helm_release` and `helm_template` resources. When true, the JSON schema validation step is skipped during chart installation, upgrade, and template rendering.

Closes #1609