### PR TITLE
Fix #1727: Document postrender syntax change from block to attribute in v3

### DIFF
--- a/docs/guides/v3-upgrade-guide.md
+++ b/docs/guides/v3-upgrade-guide.md
@@ -177,6 +177,42 @@ resource "helm_release" "nginx_ingress" {
 
 - `set`, `set_list`, and `set_sensitive` is now a list of nested objects using `[ { ... } ]`.
 
+#### `postrender` Configuration
+
+The `postrender` attribute has been changed from a block to a single nested object attribute.
+
+**Old SDKv2 Configuration:**
+
+```hcl
+resource "helm_release" "example" {
+  name  = "my-release"
+  chart = "my-chart"
+
+  postrender {
+    binary_path = "/path/to/post-renderer"
+    args        = ["arg1", "arg2"]
+  }
+}
+```
+
+**New Plugin Framework Configuration:**
+
+```hcl
+resource "helm_release" "example" {
+  name  = "my-release"
+  chart = "my-chart"
+
+  postrender = {
+    binary_path = "/path/to/post-renderer"
+    args        = ["arg1", "arg2"]
+  }
+}
+```
+
+**What Changed?**
+
+- `postrender` is now a single nested object attribute using `= { ... }` instead of a block using `{ ... }`.
+
 ### Changes to helm_template Data Source
 
 #### `set`, `set_list`, and `set_sensitive` Configuration

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -37,7 +37,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `max_history` (Number) Limit the maximum number of revisions saved per release. Use 0 for no limit. Defaults to 0 (no limit).
 - `namespace` (String) Namespace to install the release into. Defaults to `default`.
 - `pass_credentials` (Boolean) Pass credentials to all domains. Defaults to `false`.
-- `postrender` (Block List, Max: 1) Postrender command configuration. (see [below for nested schema](#nestedblock--postrender))
+- `postrender` (Attribute List, Max: 1) Postrender command configuration. (see [below for nested schema](#nestedatt--postrender))
 - `recreate_pods` (Boolean) Perform pods restart during upgrade/rollback. Defaults to `false`.
 - `render_subchart_notes` (Boolean) If set, render subchart notes along with the parent. Defaults to `true`.
 - `replace` (Boolean) Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`.
@@ -72,7 +72,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `metadata` (List of Object) Status of the deployed release. (see [below for nested schema](#nestedatt--metadata))
 - `status` (String) Status of the release.
 
-<a id="nestedblock--postrender"></a>
+<a id="nestedatt--postrender"></a>
 ### Nested Schema for `postrender`
 
 Required:
@@ -329,7 +329,7 @@ set = [
 
 ```
 
-The `postrender` block supports two attributes:
+The `postrender` attribute supports two attributes:
 
 * `binary_path` - (Required) relative or full path to command binary.
 * `args` - (Optional) a list of arguments to supply to the post-renderer.


### PR DESCRIPTION
## Description

This PR documents the breaking change in v3 where `postrender` changed from a block (`postrender { ... }`) to a single nested object attribute (`postrender = { ... }`).

## Changes

1. **docs/resources/release.md**: Updated `postrender` type from `(Block List, Max: 1)` to `(Attribute List, Max: 1)` and corrected the anchor from `nestedblock--postrender` to `nestedatt--postrender`. Also updated prose reference from "block" to "attribute".

2. **docs/guides/v3-upgrade-guide.md**: Added a new `postrender` section under `Changes to helm_release Resource` showing old vs new syntax with examples.

Fixes #1727