### PR TITLE
Fix #1493: Remove OCI login caching to support short-lived credential rotation

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -48,10 +48,9 @@ type Meta struct {
 	RegistryClient *registry.Client
 	HelmDriver     string
 	// Experimental feature toggles
-	Experiments           map[string]bool
-	Mutex                 sync.Mutex
-	loggedInOCIRegistries map[string]struct{}
-	ChartPathMutex        sync.Mutex
+	Experiments    map[string]bool
+	Mutex          sync.Mutex
+	ChartPathMutex sync.Mutex
 }
 
 // LocateChart serializes calls to cpo.LocateChart to avoid concurrent writes to Helm's shared repository cache.
@@ -603,7 +602,6 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		Experiments: map[string]bool{
 			"manifest": manifestExperiment,
 		},
-		loggedInOCIRegistries: make(map[string]struct{}),
 	}
 	registryClient, err := registry.NewClient()
 	if err != nil {
@@ -692,23 +690,14 @@ func OCIRegistryLogin(ctx context.Context, meta *Meta, actionConfig *action.Conf
 
 // registryClient = client used to comm with the registry, oci urls, un, and pw used for authentication
 func OCIRegistryPerformLogin(ctx context.Context, meta *Meta, registryClient *registry.Client, ociURL, username, password string) error {
-	// getting the oci url, and extracting the host.
 	u, err := url.Parse(ociURL)
 	if err != nil {
 		return fmt.Errorf("could not parse OCI registry URL: %v", err)
 	}
-	meta.Mutex.Lock()
-	defer meta.Mutex.Unlock()
-	if _, ok := meta.loggedInOCIRegistries[u.Host]; ok {
-		tflog.Info(ctx, fmt.Sprintf("Already logged into OCI registry %q", u.Host))
-		return nil
-	}
-	// Now we perform the login, with the provided username and password by calling the login method
 	err = registryClient.Login(u.Host, registry.LoginOptBasicAuth(username, password))
 	if err != nil {
 		return fmt.Errorf("could not login to OCI registry %q: %v", u.Host, err)
 	}
-	meta.loggedInOCIRegistries[u.Host] = struct{}{}
 	tflog.Info(ctx, fmt.Sprintf("Logged into OCI registry %q", u.Host))
 	return nil
 }


### PR DESCRIPTION
## Description

When using OCI registries that require short-lived credentials (like ECR), the provider cached the login state in  and skipped re-authentication on subsequent calls. Once the token expired, operations would fail with authentication errors.

## Changes

- Removed  cache field from  struct
- Removed the cache check + skip logic in 
- The provider now always attempts login when credentials are provided

Fixes #1493