### PR TITLE
Feat #1630: Add set_wo attribute to helm_template data source

### DIFF
--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -57,6 +57,7 @@ For further details on the `helm template` command, refer to the [Helm documenta
 - `set_list` (Block List) Custom list values to be merged with the values. (see [below for nested schema](#nestedblock--set_list))
 - `set_sensitive` (Block Set) Custom sensitive values to be merged with the values. (see [below for nested schema](#nestedblock--set_sensitive))
 - `set_string` (Block Set, Deprecated) Custom string values to be merged with the values. (see [below for nested schema](#nestedblock--set_string))
+- `set_wo` (Block List) Write-only custom values to be merged with the values. (see [below for nested schema](#nestedblock--set_wo))
 - `show_only` (List of String) Only show manifests rendered from the given templates
 - `skip_crds` (Boolean) If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`.
 - `skip_tests` (Boolean) If set, tests will not be rendered. By default, tests are rendered. Defaults to `false`.
@@ -121,7 +122,17 @@ Required:
 
 - `name` (String)
 - `value` (String)
+<a id="nestedblock--set_wo"></a>
+### Nested Schema for `set_wo`
 
+Required:
+
+- `name` (String)
+- `value` (String, Sensitive)
+
+Optional:
+
+- `type` (String)
 
 
 

--- a/docs/guides/v3-upgrade-guide.md
+++ b/docs/guides/v3-upgrade-guide.md
@@ -177,6 +177,42 @@ resource "helm_release" "nginx_ingress" {
 
 - `set`, `set_list`, and `set_sensitive` is now a list of nested objects using `[ { ... } ]`.
 
+#### `postrender` Configuration
+
+The `postrender` attribute has been changed from a block to a single nested object attribute.
+
+**Old SDKv2 Configuration:**
+
+```hcl
+resource "helm_release" "example" {
+  name  = "my-release"
+  chart = "my-chart"
+
+  postrender {
+    binary_path = "/path/to/post-renderer"
+    args        = ["arg1", "arg2"]
+  }
+}
+```
+
+**New Plugin Framework Configuration:**
+
+```hcl
+resource "helm_release" "example" {
+  name  = "my-release"
+  chart = "my-chart"
+
+  postrender = {
+    binary_path = "/path/to/post-renderer"
+    args        = ["arg1", "arg2"]
+  }
+}
+```
+
+**What Changed?**
+
+- `postrender` is now a single nested object attribute using `= { ... }` instead of a block using `{ ... }`.
+
 ### Changes to helm_template Data Source
 
 #### `set`, `set_list`, and `set_sensitive` Configuration

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -37,7 +37,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `max_history` (Number) Limit the maximum number of revisions saved per release. Use 0 for no limit. Defaults to 0 (no limit).
 - `namespace` (String) Namespace to install the release into. Defaults to `default`.
 - `pass_credentials` (Boolean) Pass credentials to all domains. Defaults to `false`.
-- `postrender` (Block List, Max: 1) Postrender command configuration. (see [below for nested schema](#nestedblock--postrender))
+- `postrender` (Attribute List, Max: 1) Postrender command configuration. (see [below for nested schema](#nestedatt--postrender))
 - `recreate_pods` (Boolean) Perform pods restart during upgrade/rollback. Defaults to `false`.
 - `render_subchart_notes` (Boolean) If set, render subchart notes along with the parent. Defaults to `true`.
 - `replace` (Boolean) Re-use the given name, even if that name is already used. This is unsafe in production. Defaults to `false`.
@@ -72,7 +72,7 @@ A Chart is a Helm package. It contains all of the resource definitions necessary
 - `metadata` (List of Object) Status of the deployed release. (see [below for nested schema](#nestedatt--metadata))
 - `status` (String) Status of the release.
 
-<a id="nestedblock--postrender"></a>
+<a id="nestedatt--postrender"></a>
 ### Nested Schema for `postrender`
 
 Required:
@@ -329,7 +329,7 @@ set = [
 
 ```
 
-The `postrender` block supports two attributes:
+The `postrender` attribute supports two attributes:
 
 * `binary_path` - (Required) relative or full path to command binary.
 * `args` - (Optional) a list of arguments to supply to the post-renderer.

--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -353,7 +353,8 @@ func (d *HelmTemplate) Schema(ctx context.Context, req datasource.SchemaRequest,
 							Required: true,
 						},
 						"value": schema.StringAttribute{
-							Required: true,
+							Required:  true,
+							Sensitive: true,
 						},
 						"type": schema.StringAttribute{
 							Optional: true,


### PR DESCRIPTION
Adds `set_wo` (write-only set values) to the `helm_template` data source, matching the existing `set_wo` attribute on `helm_release`.

Changes:
- Mark the `value` field in `set_wo` as `Sensitive: true` to ensure write-only behavior
- Update documentation with `set_wo` nested schema

Closes #1630