### PR TITLE
Feat #1561: Use jsontypes.Normalized for manifest attribute to improve diff output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.16.0
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.6.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/hashicorp/terraform-plugin-docs v0.20.1 h1:Fq7E/HrU8kuZu3hNliZGwloFWS
 github.com/hashicorp/terraform-plugin-docs v0.20.1/go.mod h1:Yz6HoK7/EgzSrHPB9J/lWFzwl9/xep2OPnc5jaJDV90=
 github.com/hashicorp/terraform-plugin-framework v1.16.0 h1:tP0f+yJg0Z672e7levixDe5EpWwrTrNryPM9kDMYIpE=
 github.com/hashicorp/terraform-plugin-framework v1.16.0/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.6.0 h1:Vv16e7EW4nT9668IV0RhdpEmnLl0im7BZx6J+QMlUkg=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.6.0/go.mod h1:rpHo9hZLn4vEkvNL5xsSdLRdaDZKSinuc0xL+BdOpVA=
 github.com/hashicorp/terraform-plugin-framework-validators v0.13.0 h1:bxZfGo9DIUoLLtHMElsu+zwqI4IsMZQBRRy4iLzZJ8E=

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -49,8 +49,8 @@ type Meta struct {
 	HelmDriver     string
 	// Experimental feature toggles
 	Experiments           map[string]bool
-	Mutex                 sync.Mutex
-	loggedInOCIRegistries map[string]struct{}
+	registryMutexes       sync.Map
+	loggedInOCIRegistries sync.Map
 	ChartPathMutex        sync.Mutex
 }
 
@@ -603,7 +603,7 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		Experiments: map[string]bool{
 			"manifest": manifestExperiment,
 		},
-		loggedInOCIRegistries: make(map[string]struct{}),
+
 	}
 	registryClient, err := registry.NewClient()
 	if err != nil {
@@ -692,23 +692,32 @@ func OCIRegistryLogin(ctx context.Context, meta *Meta, actionConfig *action.Conf
 
 // registryClient = client used to comm with the registry, oci urls, un, and pw used for authentication
 func OCIRegistryPerformLogin(ctx context.Context, meta *Meta, registryClient *registry.Client, ociURL, username, password string) error {
-	// getting the oci url, and extracting the host.
 	u, err := url.Parse(ociURL)
 	if err != nil {
 		return fmt.Errorf("could not parse OCI registry URL: %v", err)
 	}
-	meta.Mutex.Lock()
-	defer meta.Mutex.Unlock()
-	if _, ok := meta.loggedInOCIRegistries[u.Host]; ok {
+
+	if _, ok := meta.loggedInOCIRegistries.Load(u.Host); ok {
 		tflog.Info(ctx, fmt.Sprintf("Already logged into OCI registry %q", u.Host))
 		return nil
 	}
-	// Now we perform the login, with the provided username and password by calling the login method
+
+	actualMutex, _ := meta.registryMutexes.LoadOrStore(u.Host, &sync.Mutex{})
+	mu := actualMutex.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, ok := meta.loggedInOCIRegistries.Load(u.Host); ok {
+		tflog.Info(ctx, fmt.Sprintf("Already logged into OCI registry %q", u.Host))
+		return nil
+	}
+
 	err = registryClient.Login(u.Host, registry.LoginOptBasicAuth(username, password))
 	if err != nil {
 		return fmt.Errorf("could not login to OCI registry %q: %v", u.Host, err)
 	}
-	meta.loggedInOCIRegistries[u.Host] = struct{}{}
+
+	meta.loggedInOCIRegistries.Store(u.Host, struct{}{})
 	tflog.Info(ctx, fmt.Sprintf("Logged into OCI registry %q", u.Host))
 	return nil
 }

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -82,7 +83,7 @@ type HelmReleaseModel struct {
 	ID                       types.String     `tfsdk:"id"`
 	Keyring                  types.String     `tfsdk:"keyring"`
 	Lint                     types.Bool       `tfsdk:"lint"`
-	Manifest                 types.String     `tfsdk:"manifest"`
+	Manifest                 jsontypes.Normalized `tfsdk:"manifest"`
 	MaxHistory               types.Int64      `tfsdk:"max_history"`
 	Metadata                 types.Object     `tfsdk:"metadata"`
 	Name                     types.String     `tfsdk:"name"`
@@ -356,6 +357,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: "Run helm lint when planning",
 			},
 			"manifest": schema.StringAttribute{
+				CustomType:  jsontypes.NormalizedType{},
 				Description: "The rendered manifest as JSON.",
 				Computed:    true,
 			},
@@ -1666,7 +1668,7 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 	var diags diag.Diagnostics
 	// Update state with attributes from the helm release
 	state.Resources = types.MapNull(types.StringType)
-	state.Manifest = types.StringNull()
+	state.Manifest = jsontypes.NewNormalizedNull()
 	state.Name = types.StringValue(r.Name)
 	version := r.Chart.Metadata.Version
 	if !versionsEqual(version, state.Version.ValueString()) {
@@ -1716,7 +1718,7 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 		}
 		sensitiveValues := extractSensitiveValues(state)
 		manifest := redactSensitiveValues(string(jsonManifest), sensitiveValues)
-		state.Manifest = types.StringValue(manifest)
+		state.Manifest = jsontypes.NewNormalizedValue(manifest)
 
 		resources, resDiags := getLiveResources(ctx, r, meta)
 		diags.Append(resDiags...)
@@ -2025,7 +2027,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		// Check if all necessary values are known
 		if valuesUnknown(plan) {
 			tflog.Debug(ctx, "not all values are known, skipping dry run to render manifest")
-			plan.Manifest = types.StringUnknown()
+			plan.Manifest = jsontypes.NewNormalizedUnknown()
 			plan.Resources = types.MapUnknown(types.StringType)
 			if config.Version.IsNull() {
 				plan.Version = types.StringUnknown()
@@ -2091,7 +2093,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 
 				if strings.Contains(err.Error(), "Kubernetes cluster unreachable") {
 					resp.Diagnostics.AddError("cluster was unreachable at create time, marking manifest as computed", err.Error())
-					plan.Manifest = types.StringNull()
+					plan.Manifest = jsontypes.NewNormalizedNull()
 					resp.Plan.Set(ctx, &plan)
 					return
 				}
@@ -2118,7 +2120,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 				}
 			}
 			manifest := redactSensitiveValues(string(jsonManifest), valuesMap)
-			plan.Manifest = types.StringValue(manifest)
+			plan.Manifest = jsontypes.NewNormalizedValue(manifest)
 			resources, resDiags := getDryRunResources(ctx, dry, meta)
 			resp.Diagnostics.Append(resDiags...)
 			if resp.Diagnostics.HasError() {
@@ -2135,7 +2137,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 			if len(chart.Metadata.Version) > 0 {
 				plan.Version = types.StringValue(chart.Metadata.Version)
 			}
-			plan.Manifest = types.StringNull()
+			plan.Manifest = jsontypes.NewNormalizedNull()
 			plan.Resources = types.MapNull(types.StringType)
 			resp.Plan.Set(ctx, &plan)
 			return
@@ -2178,7 +2180,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 				plan.Version = types.StringValue(chart.Metadata.Version)
 			}
 			plan.Version = types.StringNull()
-			plan.Manifest = types.StringNull()
+			plan.Manifest = jsontypes.NewNormalizedNull()
 			plan.Resources = types.MapNull(types.StringType)
 			resp.Plan.Set(ctx, &plan)
 			return
@@ -2206,7 +2208,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 			}
 		}
 		manifest := redactSensitiveValues(string(jsonManifest), valuesMap)
-		plan.Manifest = types.StringValue(manifest)
+		plan.Manifest = jsontypes.NewNormalizedValue(manifest)
 		resources, resDiags := getDryRunResources(ctx, dry, meta)
 		resp.Diagnostics.Append(resDiags...)
 		if resp.Diagnostics.HasError() {
@@ -2225,7 +2227,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		}
 
 	} else {
-		plan.Manifest = types.StringNull()
+		plan.Manifest = jsontypes.NewNormalizedNull()
 		plan.Resources = types.MapNull(types.StringType)
 	}
 


### PR DESCRIPTION
## Description

Switches the `manifest` attribute from `types.String` to `jsontypes.Normalized` (from `terraform-plugin-framework-jsontypes`) to normalize JSON formatting and produce cleaner diffs.

### Changes

- **Model**: Changed `HelmReleaseModel.Manifest` from `types.String` to `jsontypes.Normalized`
- **Schema**: Added `CustomType: jsontypes.NormalizedType{}` to the manifest attribute
- **Assignments**: Updated all `state.Manifest` and `plan.Manifest` assignments to use `jsontypes.NewNormalized*` functions
- **Dependencies**: Added `github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0`

Closes #1561