### PR TITLE
Fix #1685: Ensure repository cache directory exists and improve chart location error messages

### DIFF
--- a/helm/provider.go
+++ b/helm/provider.go
@@ -515,6 +515,15 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if repositoryCache != "" {
 		settings.RepositoryCache = repositoryCache
 	}
+
+	if err := os.MkdirAll(settings.RepositoryCache, os.ModePerm); err != nil {
+		resp.Diagnostics.AddError(
+			"Repository Cache Directory Creation Failed",
+			fmt.Sprintf("Unable to create repository cache directory %s: %s", settings.RepositoryCache, err),
+		)
+		return
+	}
+
 	tflog.Debug(ctx, "Helm settings initialized", map[string]interface{}{
 		"settings": settings,
 	})

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1394,7 +1394,7 @@ func getChart(ctx context.Context, model *HelmReleaseModel, m *Meta, name string
 
 	path, err := m.LocateChart(cpo, name)
 	if err != nil {
-		diags.AddError("Error locating chart", fmt.Sprintf("Unable to locate chart %s: %s", name, err))
+		diags.AddError("Error locating chart", fmt.Sprintf("Unable to locate chart %s: %s\n\nTry running 'helm repo update' to refresh your repository cache, or verify the chart name and repository are correct.", name, err))
 		return nil, "", diags
 	}
 


### PR DESCRIPTION
## Description

This PR fixes #1685 - the "Error locating chart" error that occurs when the Helm repository cache directory does not exist before resolving charts.

## Changes

1. **provider.go**: Added `os.MkdirAll` call in the `Configure` method to ensure the repository cache directory exists before any chart resolution occurs.

2. **resource_helm_release.go**: Improved the error message in `getChart` to suggest running `helm repo update` or verifying the chart name and repository.

## Testing

- [ ] Unit tests pass
- [ ] Manual verification with a Helm chart that previously failed with the cache directory error