### PR TITLE
Fix #1716: Return error diagnostic instead of removing resource from state on permission errors

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1016,12 +1016,12 @@ func (r *HelmRelease) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	exists, diags := resourceReleaseExists(ctx, state.Name.ValueString(), state.Namespace.ValueString(), meta)
-	if !exists {
-		resp.State.RemoveResource(ctx)
-		return
-	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !exists {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -1252,11 +1252,11 @@ func (r *HelmRelease) Delete(ctx context.Context, req resource.DeleteRequest, re
 	namespace := state.Namespace.ValueString()
 
 	exists, diags := resourceReleaseExists(ctx, name, namespace, meta)
-	if !exists {
-		return
-	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !exists {
 		return
 	}
 


### PR DESCRIPTION
When the GKE service account lacks `container.secrets.list` permission, Helm's `Get` action returns a Kubernetes API permission error rather than 'release: not found'. The Read function was checking `!exists` before appending diagnostics, causing permission errors to silently remove the resource from state and plan a recreation.

This fix moves the diagnostics append and error check `before` the `!exists` check, so any non-'not found' error (like a permission error) correctly propagates as an error diagnostic to the user.

Applies the same fix to the Delete function which had the same bug pattern.