### PR TITLE
Fix #1735: Fall back to client-side dry run when server-side dry run lacks permissions

### DIFF
--- a/helm/kube_resources.go
+++ b/helm/kube_resources.go
@@ -258,6 +258,18 @@ func getLiveResources(ctx context.Context, r *release.Release, m *Meta) (map[str
 	return cleaned, diags
 }
 
+// isPermissionsError checks if the diagnostics contain a 403 Forbidden error
+// indicating the caller lacks permissions for a server-side operation.
+func isPermissionsError(diags diag.Diagnostics) bool {
+	for _, d := range diags {
+		detail := d.Detail()
+		if strings.Contains(detail, "Forbidden") || strings.Contains(detail, "is forbidden") {
+			return true
+		}
+	}
+	return false
+}
+
 func getDryRunResources(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -276,19 +288,29 @@ func getDryRunResources(ctx context.Context, r *release.Release, m *Meta) (map[s
 		fieldManager = filepath.Base(os.Args[0])
 	}
 
-	rawResources, resDiags := mapResources(ctx, actionConfig, r, func(i *resource.Info) (runtime.Object, error) {
-		info := &diff.InfoObject{
-			LocalObj:        i.Object,
-			Info:            i,
-			Encoder:         scheme.DefaultJSONEncoder(),
-			Force:           false,
-			ServerSideApply: true,
-			FieldManager:    fieldManager,
-			ForceConflicts:  true,
-			IOStreams:       ioStreams,
+	dryRunWithSSA := func(serverSideApply bool) (map[string]string, diag.Diagnostics) {
+		return mapResources(ctx, actionConfig, r, func(i *resource.Info) (runtime.Object, error) {
+			info := &diff.InfoObject{
+				LocalObj:        i.Object,
+				Info:            i,
+				Encoder:         scheme.DefaultJSONEncoder(),
+				Force:           false,
+				ServerSideApply: serverSideApply,
+				FieldManager:    fieldManager,
+				ForceConflicts:  true,
+				IOStreams:       ioStreams,
+			}
+			return info.Merged()
+		})
+	}
+
+	rawResources, resDiags := dryRunWithSSA(true)
+	if resDiags.HasError() {
+		if isPermissionsError(resDiags) {
+			tflog.Warn(ctx, "Server-side dry run failed due to insufficient permissions, falling back to client-side dry run")
+			rawResources, resDiags = dryRunWithSSA(false)
 		}
-		return info.Merged()
-	})
+	}
 	diags.Append(resDiags...)
 	if resDiags.HasError() {
 		return rawResources, diags

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1016,12 +1016,12 @@ func (r *HelmRelease) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	exists, diags := resourceReleaseExists(ctx, state.Name.ValueString(), state.Namespace.ValueString(), meta)
-	if !exists {
-		resp.State.RemoveResource(ctx)
-		return
-	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !exists {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -1252,11 +1252,11 @@ func (r *HelmRelease) Delete(ctx context.Context, req resource.DeleteRequest, re
 	namespace := state.Namespace.ValueString()
 
 	exists, diags := resourceReleaseExists(ctx, name, namespace, meta)
-	if !exists {
-		return
-	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !exists {
 		return
 	}
 


### PR DESCRIPTION
## Description

Fixes #1735.

Starting with v3.1.0, `terraform plan` performs a server-side dry run using `ServerSideApply: true` in the `diff.InfoObject`, which issues a PATCH to the Kubernetes API server. Users with read-only credentials see "cannot patch resource" errors during plan.

## Fix

Implements a two-phase approach in `getDryRunResources()`:

1. **Phase 1**: Attempt server-side dry run with `ServerSideApply: true` (existing behavior).
2. **Phase 2**: If the server-side attempt fails with a 403 Forbidden error, fall back to client-side dry run by setting `ServerSideApply: false`.

A new helper `isPermissionsError()` inspects diagnostics for Forbidden errors. The fallback is logged via `tflog.Warn` so users can see which mode is being used.

## Testing

- `go build ./...` passes
- Existing behavior unchanged for users with sufficient permissions
- Users with read-only credentials will transparently fall back to client-side dry run