### PR TITLE
Fix #1670: Include merged inline values when running helm lint

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2013,7 +2013,7 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	}
 
 	if plan.Lint.ValueBool() {
-		diags := resourceReleaseValidate(ctx, &plan, meta, cpo)
+		diags := resourceReleaseValidate(ctx, &plan, &config, meta, cpo)
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
@@ -2309,7 +2309,7 @@ func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
 	return false
 }
 
-func resourceReleaseValidate(ctx context.Context, model *HelmReleaseModel, meta *Meta, cpo *action.ChartPathOptions) diag.Diagnostics {
+func resourceReleaseValidate(ctx context.Context, model *HelmReleaseModel, config *HelmReleaseModel, meta *Meta, cpo *action.ChartPathOptions) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	cpo, name, chartDiags := chartPathOptions(model, meta, cpo)
@@ -2323,6 +2323,17 @@ func resourceReleaseValidate(ctx context.Context, model *HelmReleaseModel, meta 
 	diags.Append(valuesDiags...)
 	if diags.HasError() {
 		return diags
+	}
+
+	if config != nil && config.SetWORevision.ValueInt64() > 0 {
+		woValues, woDiags := getWriteOnlyValues(ctx, config)
+		diags.Append(woDiags...)
+		if diags.HasError() {
+			return diags
+		}
+		if len(woValues) > 0 {
+			values = mergeMaps(values, woValues)
+		}
 	}
 
 	lintDiags := lintChart(meta, name, cpo, values)


### PR DESCRIPTION
## Description

Fix #1670

After upgrading to v3, `helm lint` fails because it no longer passes inline values (from `set`, `set_sensitive`, `set_string`, and `values` blocks) to the Helm linter. Users get "nil pointer evaluating interface{}" errors because values are not available during template validation.

## Root Cause

The `resourceReleaseValidate` function (called when `lint = true`) calls `getValues()` which merges all regular value sources (`values`, `set`, `set_list`, `set_sensitive`). However, it did not merge write-only values (`set_wo`) that are stored separately in terraform's config model. The Create and Update paths already handle this correctly by calling `getWriteOnlyValues` separately and merging them.

## Fix

- Modified `resourceReleaseValidate` to accept the config model as a parameter
- When `SetWORevision > 0`, call `getWriteOnlyValues` and merge them with the rest of the values before passing to the Helm linter