### PR TITLE
Fix #1688: Defer chart resolution to apply time when local chart path doesn't exist during plan

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1971,6 +1971,30 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	// Always set desired state to DEPLOYED
 	plan.Status = types.StringValue(release.StatusDeployed.String())
 
+	// If the chart is a local path that doesn't exist yet (e.g., being generated
+	// by another resource), defer chart resolution to apply time.
+	if state == nil {
+		chartPath := plan.Chart.ValueString()
+		if _, err := os.Stat(chartPath); os.IsNotExist(err) {
+			if !strings.Contains(chartPath, "://") {
+				repo := plan.Repository.ValueString()
+				if repo == "" || (!strings.Contains(repo, "://") && func() bool { _, err := os.Stat(repo); return os.IsNotExist(err) }()) {
+					tflog.Debug(ctx, fmt.Sprintf("Chart path %q does not exist yet, deferring chart resolution to apply time", chartPath))
+					plan.Manifest = types.StringUnknown()
+					plan.Resources = types.MapUnknown(types.StringType)
+					if config.Version.IsNull() {
+						plan.Version = types.StringUnknown()
+					}
+					plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
+					resp.Diagnostics.AddWarning("Chart not found",
+						fmt.Sprintf("Chart %q does not exist yet. The chart will be resolved at apply time.", chartPath))
+					resp.Plan.Set(ctx, &plan)
+					return
+				}
+			}
+		}
+	}
+
 	if !useChartVersion(plan.Chart.ValueString(), plan.Repository.ValueString()) {
 		// Check if version has changed
 		if state != nil && !plan.Version.Equal(state.Version) {


### PR DESCRIPTION
When a local chart is rendered via local_file resources (with dependencies like time_sleep), running terraform plan fails because the plan tries to validate the chart before the render resources are created. The chart directory doesn't exist yet at plan time.

This fix adds a check in ModifyPlan: when the chart is a local path that doesn't exist yet and the resource is being created (state is nil), chart resolution is deferred to apply time. The plan marks manifest, resources, version, and metadata as unknown, and they will be resolved at apply time when all dependencies are available.