### PR TITLE
Fix #1581: Prevent cascading unknown propagation from manifest to version attribute

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -536,11 +536,14 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Default:     booldefault.StaticBool(defaultAttributes["verify"].(bool)),
 				Description: "Verify the package before installing it.",
 			},
-			"version": schema.StringAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: "Specify the exact chart version to install. If this is not specified, the latest version is installed",
+		"version": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Specify the exact chart version to install. If this is not specified, the latest version is installed",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
+		},
 			"wait": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,


### PR DESCRIPTION
## Problem

When `experiments.manifest = true` is set and a chart values reference another resource (e.g., `random_password`), the `version` attribute shows as `(known after apply)` at plan time. This happens because the `ModifyPlan` function skips the manifest dry-run when values are unknown and unnecessarily marks `version` as unknown too.

## Root Cause

In `ModifyPlan` (resource_helm_release.go:2024-2035), when the manifest experiment is enabled and values reference interpolated resources, the code skips the dry-run and sets `plan.Version = types.StringUnknown()`. The version can be resolved independently from the chart/repository and should not cascade to unknown just because the manifest is unknown.

## Fix

Added `stringplanmodifier.UseStateForUnknown()` to the `version` attribute schema. This planmodifier ensures that when the version would otherwise become unknown in the plan but was known in the state, the state value is preserved. The version resolution is independent of the manifest rendering — it only depends on the chart and repository configuration, which are always known at plan time.