### PR TITLE
Fix #463: Ensure Helm action timeout and context timeout properly propagate from config

### DIFF
--- a/helm/kubeconfig.go
+++ b/helm/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,6 +38,12 @@ type KubeConfig struct {
 // Converting KubeConfig to a REST config, which will be used to create k8s clients
 func (k *KubeConfig) ToRESTConfig() (*rest.Config, error) {
 	config, err := k.ToRawKubeConfigLoader().ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	if config.Timeout == 0 {
+		config.Timeout = 300 * time.Second
+	}
 	return config, err
 }
 

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -770,6 +770,11 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	attrTimeout := time.Duration(state.Timeout.ValueInt64()) * time.Second
+	if attrTimeout > createTimeout {
+		createTimeout = attrTimeout
+	}
+
 	var config HelmReleaseModel
 	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
@@ -854,7 +859,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 	client.Devel = state.Devel.ValueBool()
 	client.DependencyUpdate = state.DependencyUpdate.ValueBool()
 	client.TakeOwnership = state.TakeOwnership.ValueBool()
-	client.Timeout = time.Duration(state.Timeout.ValueInt64()) * time.Second
+	client.Timeout = createTimeout
 	client.Namespace = state.Namespace.ValueString()
 	client.ReleaseName = state.Name.ValueString()
 	client.Atomic = state.Atomic.ValueBool()
@@ -897,7 +902,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 		upgradeClient.DisableHooks = state.DisableWebhooks.ValueBool()
 		upgradeClient.Wait = state.Wait.ValueBool()
 		upgradeClient.Devel = state.Devel.ValueBool()
-		upgradeClient.Timeout = time.Duration(state.Timeout.ValueInt64()) * time.Second
+		upgradeClient.Timeout = createTimeout
 		upgradeClient.Namespace = state.Namespace.ValueString()
 		upgradeClient.Atomic = state.Atomic.ValueBool()
 		upgradeClient.SkipCRDs = state.SkipCrds.ValueBool()
@@ -922,7 +927,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 			}
 		}
 
-		rel, err = upgradeClient.Run(releaseName, c, values)
+		rel, err = upgradeClient.RunWithContext(ctx, releaseName, c, values)
 	} else {
 		tflog.Debug(ctx, fmt.Sprintf("Installing chart %q", releaseName))
 		if state.PostRender != nil {
@@ -944,7 +949,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 				client.PostRenderer = pr
 			}
 		}
-		rel, err = client.Run(c, values)
+		rel, err = client.RunWithContext(ctx, c, values)
 	}
 	if err != nil && rel == nil {
 		resp.Diagnostics.AddError("installation failed", err.Error())
@@ -1083,6 +1088,10 @@ func (r *HelmRelease) Update(ctx context.Context, req resource.UpdateRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	attrTimeout := time.Duration(plan.Timeout.ValueInt64()) * time.Second
+	if attrTimeout > updateTimeout {
+		updateTimeout = attrTimeout
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
@@ -1141,7 +1150,7 @@ func (r *HelmRelease) Update(ctx context.Context, req resource.UpdateRequest, re
 	client.Devel = plan.Devel.ValueBool()
 	client.Namespace = plan.Namespace.ValueString()
 	client.TakeOwnership = plan.TakeOwnership.ValueBool()
-	client.Timeout = time.Duration(plan.Timeout.ValueInt64()) * time.Second
+	client.Timeout = updateTimeout
 	client.Wait = plan.Wait.ValueBool()
 	client.WaitForJobs = plan.WaitForJobs.ValueBool()
 	client.DryRun = false
@@ -1193,7 +1202,7 @@ func (r *HelmRelease) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	name := plan.Name.ValueString()
-	release, err := client.Run(name, c, values)
+	release, err := client.RunWithContext(ctx, name, c, values)
 	if err != nil {
 		resp.Diagnostics.AddError("Error upgrading chart", fmt.Sprintf("Upgrade failed: %s", err))
 		return
@@ -1232,6 +1241,10 @@ func (r *HelmRelease) Delete(ctx context.Context, req resource.DeleteRequest, re
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	attrTimeout := time.Duration(state.Timeout.ValueInt64()) * time.Second
+	if attrTimeout > deleteTimeout {
+		deleteTimeout = attrTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
@@ -1276,7 +1289,7 @@ func (r *HelmRelease) Delete(ctx context.Context, req resource.DeleteRequest, re
 	uninstall := action.NewUninstall(actionConfig)
 	uninstall.Wait = state.Wait.ValueBool()
 	uninstall.DisableHooks = state.DisableWebhooks.ValueBool()
-	uninstall.Timeout = time.Duration(state.Timeout.ValueInt64()) * time.Second
+	uninstall.Timeout = deleteTimeout
 
 	// Uninstall the release
 	tflog.Info(ctx, fmt.Sprintf("Uninstalling Helm release: %s", name))


### PR DESCRIPTION
### Root Cause

The `timeout` attribute on `helm_release` was not reliably honored because:

1. **Context not propagated to Helm SDK**: The provider creates a context with timeout (from `timeouts` block) but never passes it to the Helm action. `Install.Run()`, `Upgrade.Run()`, and `Uninstall.Run()` all use `context.Background()` internally, bypassing the providers deadline.

2. **Context timeout only from timeouts block**: The context timeout was set exclusively from the Terraform `timeouts { create/update/delete }` block, ignoring the `timeout` attribute. If a user set only `timeout` (not the `timeouts` block), the context could expire before the Helm SDK finished.

3. **No default Kubernetes REST client timeout**: The `rest.Config.Timeout` was left at 0 (no timeout), meaning individual Kubernetes API requests could hang indefinitely.

### Changes

**`helm/resource_helm_release.go`**:
- Extend context timeout to `max(timeout_attr, timeouts_block)` in Create/Update/Delete so the context never cancels before the Helm SDK internal timeout.
- Set `action.Timeout` (Install/Upgrade/Uninstall) from the effective context timeout instead of the raw attribute.
- Use `Install.RunWithContext()` and `Upgrade.RunWithContext()` to propagate the provider context (with its deadline) to the Helm SDK.

**`helm/kubeconfig.go`**:
- Set a default 300s timeout on `rest.Config` in `ToRESTConfig()` to prevent indefinite hangs on Kubernetes API requests when no context deadline is present.

### Testing

- `go build ./...` passes
- `go test ./helm/...` passes (all existing tests)