### PR TITLE
Fix #1812: Preserve user's chart path expression instead of resolved absolute path in plan state

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -238,6 +238,56 @@ func suppressKeyring() planmodifier.String {
 	return suppressKeyringPlanModifier{}
 }
 
+type localChartPathPlanModifier struct{}
+
+func (m localChartPathPlanModifier) Description(ctx context.Context) string {
+	return "Preserve chart path from state for local charts on decomposed plan/apply"
+}
+
+func (m localChartPathPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m localChartPathPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	configVal := req.ConfigValue.ValueString()
+	stateVal := req.StateValue.ValueString()
+
+	if !isLocalChartPath(configVal) {
+		return
+	}
+
+	if chartIdentity(configVal) == chartIdentity(stateVal) {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func useStateForLocalChartPath() planmodifier.String {
+	return localChartPathPlanModifier{}
+}
+
+func isLocalChartPath(path string) bool {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "oci://") {
+		return false
+	}
+	return true
+}
+
+func chartIdentity(p string) string {
+	p = strings.TrimSuffix(p, "/")
+	parts := strings.Split(p, "/")
+	if len(parts) >= 2 {
+		return strings.Join(parts[len(parts)-2:], "/")
+	}
+	return p
+}
+
 func namespaceDefault() defaults.String {
 	return namespaceDefaultValue{}
 }
@@ -281,6 +331,9 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"chart": schema.StringAttribute{
 				Required:    true,
 				Description: "Chart name to be installed. A path may be used",
+				PlanModifiers: []planmodifier.String{
+					useStateForLocalChartPath(),
+				},
 			},
 			"cleanup_on_fail": schema.BoolAttribute{
 				Optional:    true,


### PR DESCRIPTION
## Description

When using a local directory path for the `chart` attribute on HCP Terraform Stacks (where plan and apply run in separate ephemeral job directories), Terraform core produces an "inconsistent final plan" error because the planned `.chart` value contains the absolute path from the plan-time working directory, which differs at apply time.

## Root Cause

On HCP Terraform Stacks, Terraform evaluates `path.module` to an absolute path during plan. This absolute-path value is stored in the plan for the `chart` attribute. At apply time, `path.module` resolves to a different directory, causing the inconsistency.

## Fix

Added a custom plan modifier (`localChartPathPlanModifier`) on the `chart` attribute that:

1. **Detects local chart paths**: Only applies to paths that are not URLs or OCI references
2. **Preserves state value**: When both the config and state values refer to the same chart identity (same trailing path components), the state value is preserved in the plan
3. **Allows genuine changes**: If the user changes the chart to a different path, the config value takes precedence

This ensures the chart path from a previous apply is carried forward when the resolved absolute path differs only due to environment differences (as happens on HCP Terraform Stacks).