### PR TITLE
Fix #829, #805: Defer manifest computation to apply time when values contain unknown plan-time references

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -2025,6 +2025,12 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		// Check if all necessary values are known
 		if valuesUnknown(plan) {
 			tflog.Debug(ctx, "not all values are known, skipping dry run to render manifest")
+			resp.Diagnostics.AddWarning(
+				"Manifest deferred to apply time",
+				"The manifest experiment is enabled, but some values contain unresolvable "+
+					"plan-time references. The manifest attribute will be computed during apply "+
+					"when all values are known. This may cause the plan to appear incomplete until apply.",
+			)
 			plan.Manifest = types.StringUnknown()
 			plan.Resources = types.MapUnknown(types.StringType)
 			if config.Version.IsNull() {
@@ -2503,6 +2509,11 @@ func valuesUnknown(plan HelmReleaseModel) bool {
 	if plan.Values.IsUnknown() {
 		return true
 	}
+	for _, v := range plan.Values.Elements() {
+		if v.IsUnknown() {
+			return true
+		}
+	}
 	if plan.SetList.IsUnknown() {
 		return true
 	}
@@ -2529,11 +2540,16 @@ func valuesUnknown(plan HelmReleaseModel) bool {
 		}
 	}
 
-	setList := []setResourceModel{}
-	plan.Set.ElementsAs(context.Background(), &setList, false)
+	setList := []set_listResourceModel{}
+	plan.SetList.ElementsAs(context.Background(), &setList, false)
 	for _, s := range setList {
 		if s.Value.IsUnknown() {
 			return true
+		}
+		for _, v := range s.Value.Elements() {
+			if v.IsUnknown() {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #829 and #805.

## Changes

1. **Add warning diagnostic when manifest is deferred**: When the manifest experiment is enabled and values contain unresolvable plan-time references, a warning is now emitted explaining that the manifest attribute will be computed during apply.

2. **Fix `valuesUnknown` function**: 
   - Added check for individual `values` elements being unknown (not just the whole list)
   - Fixed copy-paste bug where `SetList` was reading from `plan.Set` instead of `plan.SetList`, and used the wrong model type (`setResourceModel` instead of `set_listResourceModel`)
   - Added check for individual elements within `SetList` values being unknown

## Root cause

When the manifest experiment renders at plan time, the Helm SDK\u2019s `lookup` function mock can return different data at plan vs apply time. This causes a mismatch between the planned manifest and the actual manifest, resulting in the `inconsistent final plan` error. By deferring manifest computation to apply time when values are unknown, we avoid this issue entirely.