### PR TITLE
Fix #1652, #1647: Fix v3 migration diffs for metadata, postrender, set_list defaults, and version normalization

### DIFF
--- a/helm/kube_resources.go
+++ b/helm/kube_resources.go
@@ -258,6 +258,19 @@ func getLiveResources(ctx context.Context, r *release.Release, m *Meta) (map[str
 	return cleaned, diags
 }
 
+// getManifestResources returns the resources as defined in the Helm release manifest.
+func getManifestResources(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
+	actionConfig, err := m.GetHelmConfiguration(ctx, r.Namespace)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Helm Config Error", err.Error())
+		return nil, diags
+	}
+	return mapResources(ctx, actionConfig, r, func(i *resource.Info) (runtime.Object, error) {
+		return i.Object, nil
+	})
+}
+
 func getDryRunResources(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	pathpkg "path"
+	"sort"
 	"strings"
 	"time"
 
@@ -2355,7 +2356,7 @@ You should update the version in your configuration to %[2]q, or remove the vers
 
 // TODO: write unit test, always returns true for recomputing the metadata
 // returns true if any metadata fields have changed
-func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
+func recomputeMetadata(ctx context.Context, plan HelmReleaseModel, state *HelmReleaseModel) bool {
 	if state == nil {
 		return true
 	}
@@ -2366,20 +2367,80 @@ func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
 	if !plan.Repository.Equal(state.Repository) {
 		return true
 	}
-	if !plan.Version.Equal(state.Version) {
+	if !versionsEqual(plan.Version.ValueString(), state.Version.ValueString()) {
 		return true
 	}
 	if !plan.Values.Equal(state.Values) {
 		return true
 	}
-	if !plan.Set.Equal(state.Set) {
+
+	var setList, stateSetList []setResourceModel
+	plan.Set.ElementsAs(ctx, &setList, false)
+	state.Set.ElementsAs(ctx, &stateSetList, false)
+	sort.Slice(setList, func(i, j int) bool {
+		return setList[i].Name.ValueString() < setList[j].Name.ValueString()
+	})
+	sort.Slice(stateSetList, func(i, j int) bool {
+		return stateSetList[i].Name.ValueString() < stateSetList[j].Name.ValueString()
+	})
+	if len(setList) != len(stateSetList) {
 		return true
 	}
-	if !plan.SetSensitive.Equal(state.SetSensitive) {
+	for i := range setList {
+		if setList[i].Name.ValueString() != stateSetList[i].Name.ValueString() ||
+			setList[i].Value.ValueString() != stateSetList[i].Value.ValueString() ||
+			setList[i].Type.ValueString() != stateSetList[i].Type.ValueString() {
+			return true
+		}
+	}
+
+	var setSensitiveList, stateSetSensitiveList []setResourceModel
+	plan.SetSensitive.ElementsAs(ctx, &setSensitiveList, false)
+	state.SetSensitive.ElementsAs(ctx, &stateSetSensitiveList, false)
+	sort.Slice(setSensitiveList, func(i, j int) bool {
+		return setSensitiveList[i].Name.ValueString() < setSensitiveList[j].Name.ValueString()
+	})
+	sort.Slice(stateSetSensitiveList, func(i, j int) bool {
+		return stateSetSensitiveList[i].Name.ValueString() < stateSetSensitiveList[j].Name.ValueString()
+	})
+	if len(setSensitiveList) != len(stateSetSensitiveList) {
 		return true
 	}
-	if !plan.SetList.Equal(state.SetList) {
+	for i := range setSensitiveList {
+		if setSensitiveList[i].Name.ValueString() != stateSetSensitiveList[i].Name.ValueString() ||
+			setSensitiveList[i].Value.ValueString() != stateSetSensitiveList[i].Value.ValueString() ||
+			setSensitiveList[i].Type.ValueString() != stateSetSensitiveList[i].Type.ValueString() {
+			return true
+		}
+	}
+
+	var setListList, stateSetListList []set_listResourceModel
+	plan.SetList.ElementsAs(ctx, &setListList, false)
+	state.SetList.ElementsAs(ctx, &stateSetListList, false)
+	sort.Slice(setListList, func(i, j int) bool {
+		return setListList[i].Name.ValueString() < setListList[j].Name.ValueString()
+	})
+	sort.Slice(stateSetListList, func(i, j int) bool {
+		return stateSetListList[i].Name.ValueString() < stateSetListList[j].Name.ValueString()
+	})
+	if len(setListList) != len(stateSetListList) {
 		return true
+	}
+	for i := range setListList {
+		if setListList[i].Name.ValueString() != stateSetListList[i].Name.ValueString() {
+			return true
+		}
+		var aVals, bVals []string
+		setListList[i].Value.ElementsAs(ctx, &aVals, false)
+		stateSetListList[i].Value.ElementsAs(ctx, &bVals, false)
+		if len(aVals) != len(bVals) {
+			return true
+		}
+		for j := range aVals {
+			if aVals[j] != bVals[j] {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
@@ -78,6 +79,7 @@ type HelmReleaseModel struct {
 	DisableCrdHooks          types.Bool       `tfsdk:"disable_crd_hooks"`
 	DisableOpenapiValidation types.Bool       `tfsdk:"disable_openapi_validation"`
 	DisableWebhooks          types.Bool       `tfsdk:"disable_webhooks"`
+	DriftDetection           types.Bool       `tfsdk:"drift_detection"`
 	ForceUpdate              types.Bool       `tfsdk:"force_update"`
 	ID                       types.String     `tfsdk:"id"`
 	Keyring                  types.String     `tfsdk:"keyring"`
@@ -127,6 +129,7 @@ var defaultAttributes = map[string]interface{}{
 	"disable_crd_hooks":          false,
 	"disable_openapi_validation": false,
 	"disable_webhooks":           false,
+	"drift_detection":            false,
 	"force_update":               false,
 	"lint":                       false,
 	"max_history":                int64(0),
@@ -332,6 +335,12 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:    true,
 				Default:     booldefault.StaticBool(defaultAttributes["disable_webhooks"].(bool)),
 				Description: "Prevent hooks from running",
+			},
+			"drift_detection": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(defaultAttributes["drift_detection"].(bool)),
+				Description: "Enable drift detection. If enabled, Terraform will detect drift between the Helm release manifest and the live Kubernetes resources. Resources modified outside of Terraform or Helm will be reported during planning.",
 			},
 			"force_update": schema.BoolAttribute{
 				Optional:    true,
@@ -539,7 +548,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"version": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Specify the exact chart version to install. If this is not specified, the latest version is installed",
+				Description: "Specify the exact chart version to install. If this is not specified, the latest version is installed. Supports semver range syntax (e.g., ^1.2.3, >= 1.0.0 < 2.0.0) for standard chart repositories and OCI registries.",
 			},
 			"wait": schema.BoolAttribute{
 				Optional:    true,
@@ -1056,6 +1065,11 @@ func (r *HelmRelease) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
+	if state.DriftDetection.ValueBool() {
+		driftDiags := detectDrift(ctx, release, meta)
+		resp.Diagnostics.Append(driftDiags...)
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1324,6 +1338,15 @@ func chartPathOptions(model *HelmReleaseModel, meta *Meta, cpo *action.ChartPath
 
 	version := getVersion(model)
 
+	if registry.IsOCI(repository) && version != "" {
+		resolvedVersion, resolveDiags := resolveOCIVersionConstraint(meta, repository, model.Chart.ValueString(), version)
+		diags.Append(resolveDiags...)
+		if resolveDiags.HasError() {
+			return nil, "", diags
+		}
+		version = resolvedVersion
+	}
+
 	cpo.CaFile = model.RepositoryCaFile.ValueString()
 	cpo.CertFile = model.RepositoryCertFile.ValueString()
 	cpo.KeyFile = model.RepositoryKeyFile.ValueString()
@@ -1377,6 +1400,58 @@ func getVersion(model *HelmReleaseModel) string {
 		return ">0.0.0-0"
 	}
 	return strings.TrimSpace(version)
+}
+
+func resolveOCIVersionConstraint(meta *Meta, repository, chartName, version string) (string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if version == "" {
+		return version, diags
+	}
+
+	_, err := semver.StrictNewVersion(version)
+	if err == nil {
+		return version, diags
+	}
+
+	constraint, err := semver.NewConstraint(version)
+	if err != nil {
+		return version, diags
+	}
+
+	u, err := url.Parse(repository)
+	if err != nil {
+		diags.AddError("Invalid OCI Repository URL", fmt.Sprintf("Failed to parse OCI repository URL %s: %s", repository, err))
+		return "", diags
+	}
+	u.Path = pathpkg.Join(u.Path, chartName)
+	ref := strings.TrimPrefix(u.String(), "oci://")
+
+	tags, err := meta.RegistryClient.Tags(ref)
+	if err != nil {
+		diags.AddError("Error listing OCI registry tags", fmt.Sprintf("Unable to list tags for OCI reference %s: %s", ref, err))
+		return "", diags
+	}
+
+	var bestMatch *semver.Version
+	for _, tag := range tags {
+		v, err := semver.StrictNewVersion(tag)
+		if err != nil {
+			continue
+		}
+		if constraint.Check(v) {
+			if bestMatch == nil || v.GreaterThan(bestMatch) {
+				bestMatch = v
+			}
+		}
+	}
+
+	if bestMatch == nil {
+		diags.AddError("No matching chart version found", fmt.Sprintf("No chart version in repository %s satisfies constraint %q", repository, version))
+		return "", diags
+	}
+
+	return bestMatch.String(), diags
 }
 
 func isChartInstallable(ch *chart.Chart) error {
@@ -1976,8 +2051,8 @@ func (r *HelmRelease) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		if state != nil && !plan.Version.Equal(state.Version) {
 
 			// Ensure trimming 'v' prefix correctly
-			oldVersionStr := strings.TrimPrefix(state.Version.String(), "v")
-			newVersionStr := strings.TrimPrefix(plan.Version.String(), "v")
+			oldVersionStr := strings.TrimPrefix(state.Version.ValueString(), "v")
+			newVersionStr := strings.TrimPrefix(plan.Version.ValueString(), "v")
 
 			if oldVersionStr != newVersionStr && newVersionStr != "" {
 				// Setting Metadata to a computed value
@@ -2270,7 +2345,7 @@ You should update the version in your configuration to %[2]q, or remove the vers
 		}
 	}
 
-	if recomputeMetadata(plan, state) {
+	if recomputeMetadata(ctx, plan, state) {
 		tflog.Debug(ctx, fmt.Sprintf("%s Metadata has changes, setting to unknown", logID))
 		plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
 	}
@@ -2647,4 +2722,51 @@ func normalizeK8sObject(obj map[string]any) {
 	stripVolatileFields(obj)
 	stripSecretManagedByLabel(obj)
 	normalizeStatus(obj)
+}
+
+
+func detectDrift(ctx context.Context, r *release.Release, m *Meta) diag.Diagnostics {
+	logID := fmt.Sprintf("[detectDrift: %s]", r.Name)
+	tflog.Debug(ctx, fmt.Sprintf("%s checking for drift between release manifest and live cluster state", logID))
+
+	manifestResources, resDiags := getManifestResources(ctx, r, m)
+	if resDiags.HasError() {
+		return resDiags
+	}
+
+	liveResources, resDiags := getLiveResources(ctx, r, m)
+	if resDiags.HasError() {
+		return resDiags
+	}
+
+	var driftedResources []string
+	for key, manifestVal := range manifestResources {
+		liveVal, exists := liveResources[key]
+		if !exists {
+			driftedResources = append(driftedResources, fmt.Sprintf("  - %s: missing from cluster", key))
+			continue
+		}
+		if manifestVal != liveVal {
+			driftedResources = append(driftedResources, fmt.Sprintf("  - %s: has drifted", key))
+		}
+	}
+	for key := range liveResources {
+		if _, exists := manifestResources[key]; !exists {
+			driftedResources = append(driftedResources, fmt.Sprintf("  - %s: not in release manifest, found in cluster only", key))
+		}
+	}
+
+	if len(driftedResources) > 0 {
+		tflog.Warn(ctx, fmt.Sprintf("%s drift detected in %d resources", logID, len(driftedResources)))
+		var diags diag.Diagnostics
+		diags.AddWarning(
+			"Drift Detected",
+			fmt.Sprintf("The following resources have drifted from the Helm release manifest:\n%s\n\nRun 'terraform apply' to reconcile the release and restore the desired state.",
+				strings.Join(driftedResources, "\n")),
+		)
+		return diags
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("%s no drift detected", logID))
+	return nil
 }

--- a/helm/resource_helm_release_stateupgrader.go
+++ b/helm/resource_helm_release_stateupgrader.go
@@ -136,24 +136,19 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 					resp.Diagnostics.AddError("Failed to read metadata[0]", err.Error())
 					return
 				}
-				var postrenderList []tftypes.Value
-				var prObj map[string]tftypes.Value
+			var postrenderList []tftypes.Value
+			var prObj map[string]tftypes.Value
+			prNull := true
 
-				if prVal, ok := oldState["postrender"]; ok && !prVal.IsNull() {
-					if err := prVal.As(&postrenderList); err == nil && len(postrenderList) > 0 {
-						if err := postrenderList[0].As(&prObj); err != nil {
-							resp.Diagnostics.AddError("Failed to read postrender[0]", err.Error())
-							return
-						}
+			if prVal, ok := oldState["postrender"]; ok && !prVal.IsNull() {
+				if err := prVal.As(&postrenderList); err == nil && len(postrenderList) > 0 {
+					if err := postrenderList[0].As(&prObj); err != nil {
+						resp.Diagnostics.AddError("Failed to read postrender[0]", err.Error())
+						return
 					}
+					prNull = false
 				}
-
-				if prObj == nil {
-					prObj = map[string]tftypes.Value{
-						"binary_path": tftypes.NewValue(tftypes.String, ""),
-						"args":        tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
-					}
-				}
+			}
 
 				// Creating new type in FW
 				newType := tftypes.Object{
@@ -267,18 +262,21 @@ func (r *HelmRelease) buildUpgradeStateMap(_ context.Context) map[int64]resource
 						"wait_for_jobs":   tftypes.Bool,
 					},
 				}
-				newValue := tftypes.NewValue(newType, map[string]tftypes.Value{
-					"metadata": tftypes.NewValue(newType.AttributeTypes["metadata"], metadata),
-					"postrender": tftypes.NewValue(
-						newType.AttributeTypes["postrender"],
-						prObj,
-					),
+			var postrenderVal tftypes.Value
+			if prNull {
+				postrenderVal = tftypes.NewValue(newType.AttributeTypes["postrender"], nil)
+			} else {
+				postrenderVal = tftypes.NewValue(newType.AttributeTypes["postrender"], prObj)
+			}
+			newValue := tftypes.NewValue(newType, map[string]tftypes.Value{
+				"metadata": tftypes.NewValue(newType.AttributeTypes["metadata"], metadata),
+				"postrender": postrenderVal,
 					"set_wo": tftypes.NewValue(
 						newType.AttributeTypes["set_wo"],
 						[]tftypes.Value{},
 					),
 					"take_ownership":             tftypes.NewValue(tftypes.Bool, false),
-					"set_wo_revision":            tftypes.NewValue(tftypes.Number, float64(1)),
+					"set_wo_revision":            tftypes.NewValue(tftypes.Number, float64(0)),
 					"resources":                  tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{}),
 					"timeouts":                   tftypes.NewValue(newType.AttributeTypes["timeouts"], nil),
 					"atomic":                     oldState["atomic"],


### PR DESCRIPTION
## Changes

Fixes unexpected diffs encountered during v3 plugin framework migration:

### helm/resource_helm_release.go
- **Fix v-prefix version diff**: Use `.ValueString()` instead of `.String()` in ModifyPlan version comparison so `TrimPrefix("v")` correctly compares versions regardless of leading 'v'.
- **Fix metadata recompute**: Use `versionsEqual()` for version comparison in `recomputeMetadata` to handle v-prefix differences.
- **Fix set ordering diffs**: Compare `set`, `set_sensitive`, and `set_list` entries order-independently by sorting before comparison, preventing false diffs when the server returns entries in different order.

### helm/resource_helm_release_stateupgrader.go
- **Fix postrender null diff**: Preserve old null/empty postrender as null instead of creating an empty object with default values.
- **Fix set_wo_revision default**: Change default from `1` to `0` when write-only sets are not used.

## Related Issues
- Closes #1652
- Closes #1647