### PR TITLE
Fix #372: Fetch and compare deployed Helm values in Read to detect out-of-band drift

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	pathpkg "path"
 	"strings"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -1054,6 +1055,31 @@ func (r *HelmRelease) Read(ctx context.Context, req resource.ReadRequest, resp *
 			fmt.Sprintf("Unable to set attributes for helm release %s", state.Name.ValueString()),
 		)
 		return
+	}
+
+	// Detect drift in deployed values vs state-computed values (fixes #372 and #472)
+	if state.SetWORevision.ValueInt64() <= 0 {
+		deployValues := release.Config
+		if deployValues == nil {
+			deployValues = map[string]interface{}{}
+		}
+		stateValues, stateValuesDiags := getValues(ctx, &state)
+		resp.Diagnostics.Append(stateValuesDiags...)
+		if !stateValuesDiags.HasError() {
+			if stateValues == nil {
+				stateValues = map[string]interface{}{}
+			}
+			if !reflect.DeepEqual(deployValues, stateValues) {
+				tflog.Debug(ctx, fmt.Sprintf("Values drift detected for release %s", state.Name.ValueString()))
+				deployYAML, err := yaml.Marshal(deployValues)
+				if err == nil {
+					state.Values = types.ListValueMust(types.StringType, []attr.Value{
+						types.StringValue(string(deployYAML)),
+					})
+					tflog.Debug(ctx, fmt.Sprintf("Updated state values to reflect deployed values for release %s", state.Name.ValueString()))
+				}
+			}
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)


### PR DESCRIPTION
## Description

When values of a helm release are modified outside of Terraform (e.g., via `helm upgrade --set`), the provider does not detect the drift. The Read function returns the state values rather than the actual deployed values.

## Root Cause

In the `Read` function, `setReleaseAttributes` only updates `metadata.values` (a computed-only field) but never compares or updates `state.Values`, `state.Set`, `state.SetSensitive`, or `state.SetList` against the actual deployed values from `release.Config`. This means out-of-band changes via `helm upgrade` are invisible to Terraform.

## Fix

In the `Read` function, after `setReleaseAttributes`, the fix:
1. Fetches the deployed release's merged values from `release.Config`
2. Computes the expected merged values from the Terraform state using `getValues(ctx, &state)`
3. Compares them using `reflect.DeepEqual`
4. If they differ, marshals the deployed values to YAML and updates `state.Values`
5. This causes Terraform to detect the diff during planning and trigger an update

This also fixes #472 (drift from failed applies) - when a `helm upgrade` fails partway, the partially-applied values cause a mismatch that will be detected on the next read.

## Testing

- All existing tests pass
- Build compiles cleanly
- Drift is detected by comparing the actual Helm release config against what the Terraform state expects