### PR TITLE
fix: sensitive metadata suppression + missing tests + doc template fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -203,11 +203,15 @@ The `registries` block has options:
 The provider takes an `experiments` block that allows you enable experimental features by setting them to `true`.
 
 * `manifest` - Enable storing of the rendered manifest for `helm_release` so the full diff of what is changing can been seen in the plan.
+* `suppress_metadata_notes` - Suppress verbose helm chart notes from `metadata` output to reduce plan verbosity and avoid exposing potentially sensitive information in logs.
+* `suppress_metadata_values` - Suppress helm values from `metadata` output to reduce plan verbosity and avoid exposing sensitive configuration values in logs.
 
 ```terraform
 provider "helm" {
   experiments = {
     manifest = true
+    suppress_metadata_notes  = true
+    suppress_metadata_values = true
   }
 }
 ```

--- a/helm/provider.go
+++ b/helm/provider.go
@@ -82,7 +82,9 @@ type HelmProviderModel struct {
 
 // ExperimentsConfigModel configures the experiments that are enabled or disabled
 type ExperimentsConfigModel struct {
-	Manifest types.Bool `tfsdk:"manifest"`
+	Manifest               types.Bool `tfsdk:"manifest"`
+	SuppressMetadataNotes  types.Bool `tfsdk:"suppress_metadata_notes"`
+	SuppressMetadataValues types.Bool `tfsdk:"suppress_metadata_values"`
 }
 
 // RegistryConfigModel configures an OCI registry
@@ -202,6 +204,14 @@ func experimentsSchema() map[string]schema.Attribute {
 		"manifest": schema.BoolAttribute{
 			Optional:    true,
 			Description: "Enable full diff by storing the rendered manifest in the state.",
+		},
+		"suppress_metadata_notes": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Suppress verbose helm chart notes from metadata to reduce plan output size and avoid exposing potentially sensitive information in logs.",
+		},
+		"suppress_metadata_values": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Suppress helm values from metadata to reduce plan output size and avoid exposing sensitive configuration values in logs.",
 		},
 	}
 }
@@ -525,8 +535,12 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	}
 
 	manifestExperiment := false
+	suppressMetadataNotes := false
+	suppressMetadataValues := false
 	if config.Experiments != nil {
 		manifestExperiment = config.Experiments.Manifest.ValueBool()
+		suppressMetadataNotes = config.Experiments.SuppressMetadataNotes.ValueBool()
+		suppressMetadataValues = config.Experiments.SuppressMetadataValues.ValueBool()
 	}
 
 	var execAttrValue attr.Value = types.ObjectNull(execSchemaAttrTypes())
@@ -595,13 +609,17 @@ func (p *HelmProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 			BurstLimit:           types.Int64Value(burstLimit),
 			Kubernetes:           kubernetesConfigObjectValue,
 			Experiments: &ExperimentsConfigModel{
-				Manifest: types.BoolValue(manifestExperiment),
+				Manifest:               types.BoolValue(manifestExperiment),
+				SuppressMetadataNotes:  types.BoolValue(suppressMetadataNotes),
+				SuppressMetadataValues: types.BoolValue(suppressMetadataValues),
 			},
 		},
 		Settings:   settings,
 		HelmDriver: helmDriver,
 		Experiments: map[string]bool{
-			"manifest": manifestExperiment,
+			"manifest":                 manifestExperiment,
+			"suppress_metadata_notes":  suppressMetadataNotes,
+			"suppress_metadata_values": suppressMetadataValues,
 		},
 		loggedInOCIRegistries: make(map[string]struct{}),
 	}

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1743,6 +1743,17 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 		valuesstr = types.StringValue(values)
 	}
 
+	// Suppress metadata values if experiment is enabled
+	if meta.ExperimentEnabled("suppress_metadata_values") {
+		valuesstr = types.StringValue("")
+	}
+
+	// Determine notes value based on suppression experiment
+	notesValue := types.StringValue(r.Info.Notes)
+	if meta.ExperimentEnabled("suppress_metadata_notes") {
+		notesValue = types.StringValue("")
+	}
+
 	// Create metadata as a slice of maps
 	metadata := map[string]attr.Value{
 		"name":           types.StringValue(r.Name),
@@ -1754,7 +1765,7 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 		"values":         valuesstr,
 		"first_deployed": types.Int64Value(r.Info.FirstDeployed.Unix()),
 		"last_deployed":  types.Int64Value(r.Info.LastDeployed.Unix()),
-		"notes":          types.StringValue(r.Info.Notes),
+		"notes":          notesValue,
 	}
 
 	// Convert the list of ObjectValues to a ListValue

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -157,6 +157,7 @@ type releaseMetaData struct {
 	LastDeployed  types.Int64  `tfsdk:"last_deployed"`
 	Notes         types.String `tfsdk:"notes"`
 }
+
 type setResourceModel struct {
 	Name  types.String `tfsdk:"name"`
 	Type  types.String `tfsdk:"type"`
@@ -1757,11 +1758,11 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 		"notes":          types.StringValue(r.Info.Notes),
 	}
 
-	// Convert the list of ObjectValues to a ListValue
+	// Convert to ObjectValue
 	metadataObject, diag := types.ObjectValue(metadataAttrTypes(), metadata)
 	diags.Append(diag...)
 	if diags.HasError() {
-		tflog.Error(ctx, "Error converting metadata to ListValue", map[string]interface{}{
+		tflog.Error(ctx, "Error converting metadata to ObjectValue", map[string]interface{}{
 			"metadata": metadata,
 			"error":    diags,
 		})
@@ -2270,9 +2271,12 @@ You should update the version in your configuration to %[2]q, or remove the vers
 		}
 	}
 
+	// Metadata is computed during apply - don't set to unknown to avoid verbose plan output
+	// See: https://github.com/hashicorp/terraform-provider-helm/issues/1315
 	if recomputeMetadata(plan, state) {
-		tflog.Debug(ctx, fmt.Sprintf("%s Metadata has changes, setting to unknown", logID))
-		plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
+		tflog.Debug(ctx, fmt.Sprintf("%s Metadata will be recomputed during apply", logID))
+		// Keep existing state metadata in plan to suppress diff output
+		// Metadata will be properly updated during apply
 	}
 
 	resp.Plan.Set(ctx, &plan)

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -157,7 +157,6 @@ type releaseMetaData struct {
 	LastDeployed  types.Int64  `tfsdk:"last_deployed"`
 	Notes         types.String `tfsdk:"notes"`
 }
-
 type setResourceModel struct {
 	Name  types.String `tfsdk:"name"`
 	Type  types.String `tfsdk:"type"`
@@ -1758,11 +1757,11 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 		"notes":          types.StringValue(r.Info.Notes),
 	}
 
-	// Convert to ObjectValue
+	// Convert the list of ObjectValues to a ListValue
 	metadataObject, diag := types.ObjectValue(metadataAttrTypes(), metadata)
 	diags.Append(diag...)
 	if diags.HasError() {
-		tflog.Error(ctx, "Error converting metadata to ObjectValue", map[string]interface{}{
+		tflog.Error(ctx, "Error converting metadata to ListValue", map[string]interface{}{
 			"metadata": metadata,
 			"error":    diags,
 		})
@@ -2271,12 +2270,9 @@ You should update the version in your configuration to %[2]q, or remove the vers
 		}
 	}
 
-	// Metadata is computed during apply - don't set to unknown to avoid verbose plan output
-	// See: https://github.com/hashicorp/terraform-provider-helm/issues/1315
 	if recomputeMetadata(plan, state) {
-		tflog.Debug(ctx, fmt.Sprintf("%s Metadata will be recomputed during apply", logID))
-		// Keep existing state metadata in plan to suppress diff output
-		// Metadata will be properly updated during apply
+		tflog.Debug(ctx, fmt.Sprintf("%s Metadata has changes, setting to unknown", logID))
+		plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
 	}
 
 	resp.Plan.Set(ctx, &plan)

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1745,7 +1745,7 @@ func setReleaseAttributes(ctx context.Context, state *HelmReleaseModel, identity
 
 	// Suppress metadata values if experiment is enabled
 	if meta.ExperimentEnabled("suppress_metadata_values") {
-		valuesstr = types.StringValue("")
+		valuesstr = types.StringValue("{}")
 	}
 
 	// Determine notes value based on suppression experiment
@@ -2281,7 +2281,7 @@ You should update the version in your configuration to %[2]q, or remove the vers
 		}
 	}
 
-	if recomputeMetadata(plan, state) {
+	if recomputeMetadata(plan, state, meta) {
 		tflog.Debug(ctx, fmt.Sprintf("%s Metadata has changes, setting to unknown", logID))
 		plan.Metadata = types.ObjectUnknown(metadataAttrTypes())
 	}
@@ -2291,8 +2291,17 @@ You should update the version in your configuration to %[2]q, or remove the vers
 
 // TODO: write unit test, always returns true for recomputing the metadata
 // returns true if any metadata fields have changed
-func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
+func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel, meta *Meta) bool {
 	if state == nil {
+		return true
+	}
+
+	// If a metadata suppression experiment was enabled after the release was
+	// already created, prior state still holds the populated values/notes.
+	// Force a recompute so the metadata is re-derived (and blanked) at apply
+	// time, otherwise the planned metadata would differ from the applied
+	// metadata, producing an "inconsistent result after apply" error.
+	if stateMetadataNeedsSuppression(state, meta) {
 		return true
 	}
 
@@ -2315,6 +2324,47 @@ func recomputeMetadata(plan HelmReleaseModel, state *HelmReleaseModel) bool {
 		return true
 	}
 	if !plan.SetList.Equal(state.SetList) {
+		return true
+	}
+	return false
+}
+
+// stateMetadataNeedsSuppression reports whether a metadata suppression
+// experiment is enabled while the existing state still holds an unsuppressed
+// (non-empty) value for the corresponding metadata field. This detects the
+// case where a suppression experiment is retrofitted onto an already-created
+// release, so the metadata can be recomputed and blanked at apply time.
+func stateMetadataNeedsSuppression(state *HelmReleaseModel, meta *Meta) bool {
+	if meta == nil || state == nil {
+		return false
+	}
+	if state.Metadata.IsNull() || state.Metadata.IsUnknown() {
+		return false
+	}
+
+	attrs := state.Metadata.Attributes()
+	fieldPopulated := func(name string) bool {
+		v, ok := attrs[name].(types.String)
+		if !ok || v.IsNull() || v.IsUnknown() {
+			return false
+		}
+		return v.ValueString() != ""
+	}
+
+	// For values, "{}" is the suppressed sentinel — treat it as already suppressed.
+	valuesPopulated := func() bool {
+		v, ok := attrs["values"].(types.String)
+		if !ok || v.IsNull() || v.IsUnknown() {
+			return false
+		}
+		s := v.ValueString()
+		return s != "" && s != "{}"
+	}
+
+	if meta.ExperimentEnabled("suppress_metadata_values") && valuesPopulated() {
+		return true
+	}
+	if meta.ExperimentEnabled("suppress_metadata_notes") && fieldPopulated("notes") {
 		return true
 	}
 	return false

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -388,6 +388,62 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 	})
 }
 
+func TestAccResourceRelease_metadataSuppression(t *testing.T) {
+	name := randName("test-metadata-suppression")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHelmReleaseConfigMetadataSuppression(
+					testResourceName, namespace, name, "1.2.3", "initial",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+				),
+			},
+			{
+				// Update a set value - this triggers metadata recomputation
+				// but metadata is not set to unknown, so it doesn't show as changed in plan
+				Config: testAccHelmReleaseConfigMetadataSuppression(
+					testResourceName, namespace, name, "1.2.3", "updated",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+					// Verify the set value was actually updated
+					resource.TestCheckResourceAttr("helm_release.test", "set.0.value", "updated"),
+				),
+			},
+			{
+				// Update version - another metadata recomputation trigger
+				Config: testAccHelmReleaseConfigMetadataSuppression(
+					testResourceName, namespace, name, "2.0.0", "updated",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "3"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "2.0.0"),
+					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
+					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceRelease_cloakValues(t *testing.T) {
 	name := randName("test-update-values")
 	namespace := createRandomNamespace(t)
@@ -1264,6 +1320,26 @@ func testAccHelmReleaseConfigSet(resource, ns, name, version, setValue string) s
 				{
 					name  = "fizz"
 					value = 1337
+				}
+			]
+		}
+	`, resource, name, ns, testRepositoryURL, version, setValue)
+}
+
+func testAccHelmReleaseConfigMetadataSuppression(resource, ns, name, version, setValue string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+ 			name        = %q
+			namespace   = %q
+			description = "Test metadata suppression"
+			repository  = %q
+  			chart       = "test-chart"
+			version     = %q
+
+			set = [
+				{
+					name  = "testValue"
+					value = %q
 				}
 			]
 		}

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -388,62 +388,6 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 	})
 }
 
-func TestAccResourceRelease_metadataSuppression(t *testing.T) {
-	name := randName("test-metadata-suppression")
-	namespace := createRandomNamespace(t)
-	defer deleteNamespace(t, namespace)
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccHelmReleaseConfigMetadataSuppression(
-					testResourceName, namespace, name, "1.2.3", "initial",
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "1"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
-					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-				),
-			},
-			{
-				// Update a set value - this triggers metadata recomputation
-				// but metadata is not set to unknown, so it doesn't show as changed in plan
-				Config: testAccHelmReleaseConfigMetadataSuppression(
-					testResourceName, namespace, name, "1.2.3", "updated",
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "2"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "1.2.3"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
-					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-					// Verify the set value was actually updated
-					resource.TestCheckResourceAttr("helm_release.test", "set.0.value", "updated"),
-				),
-			},
-			{
-				// Update version - another metadata recomputation trigger
-				Config: testAccHelmReleaseConfigMetadataSuppression(
-					testResourceName, namespace, name, "2.0.0", "updated",
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.name", name),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.namespace", namespace),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.revision", "3"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.version", "2.0.0"),
-					resource.TestCheckResourceAttr("helm_release.test", "metadata.chart", "test-chart"),
-					resource.TestCheckResourceAttr("helm_release.test", "status", release.StatusDeployed.String()),
-				),
-			},
-		},
-	})
-}
-
 func TestAccResourceRelease_cloakValues(t *testing.T) {
 	name := randName("test-update-values")
 	namespace := createRandomNamespace(t)
@@ -1320,26 +1264,6 @@ func testAccHelmReleaseConfigSet(resource, ns, name, version, setValue string) s
 				{
 					name  = "fizz"
 					value = 1337
-				}
-			]
-		}
-	`, resource, name, ns, testRepositoryURL, version, setValue)
-}
-
-func testAccHelmReleaseConfigMetadataSuppression(resource, ns, name, version, setValue string) string {
-	return fmt.Sprintf(`
-		resource "helm_release" "%s" {
- 			name        = %q
-			namespace   = %q
-			description = "Test metadata suppression"
-			repository  = %q
-  			chart       = "test-chart"
-			version     = %q
-
-			set = [
-				{
-					name  = "testValue"
-					value = %q
 				}
 			]
 		}

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	fwtypes "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -1419,68 +1421,172 @@ func TestUseChartVersion(t *testing.T) {
 // 	}
 // }
 
-// func TestCloakSetValues(t *testing.T) {
-// 	d := resourceRelease().Data(nil)
-// 	err := d.Set("set_sensitive", []interface{}{
-// 		map[string]interface{}{"name": "foo", "value": "42"},
-// 	})
-// 	if err != nil {
-// 		t.Fatalf("error setting values: %v", err)
-// 	}
+// setSensitiveState builds a HelmReleaseModel with SetSensitive populated from
+// the given list of {name, value} pairs, ready for use in unit tests.
+func setSensitiveState(entries []struct{ name, value string }) *HelmReleaseModel {
+	setSensitiveAttrTypes := map[string]attr.Type{
+		"name":  fwtypes.StringType,
+		"type":  fwtypes.StringType,
+		"value": fwtypes.StringType,
+	}
+	elems := make([]attr.Value, 0, len(entries))
+	for _, e := range entries {
+		obj, _ := fwtypes.ObjectValue(setSensitiveAttrTypes, map[string]attr.Value{
+			"name":  fwtypes.StringValue(e.name),
+			"type":  fwtypes.StringValue(""),
+			"value": fwtypes.StringValue(e.value),
+		})
+		elems = append(elems, obj)
+	}
+	list := fwtypes.ListValueMust(fwtypes.ObjectType{AttrTypes: setSensitiveAttrTypes}, elems)
+	return &HelmReleaseModel{SetSensitive: list}
+}
 
-// 	values := map[string]interface{}{
-// 		"foo": "foo",
-// 	}
+func TestCloakSetValues(t *testing.T) {
+	state := setSensitiveState([]struct{ name, value string }{
+		{"foo", "42"},
+	})
+	values := map[string]interface{}{
+		"foo": "foo",
+	}
+	cloakSetValues(values, state)
+	if values["foo"] != sensitiveContentValue {
+		t.Fatalf("expected %q, got %s", sensitiveContentValue, values["foo"])
+	}
+}
 
-// 	cloakSetValues(values, d)
-// 	if values["foo"] != sensitiveContentValue {
-// 		t.Fatalf("error cloak values, expected %q, got %s", sensitiveContentValue, values["foo"])
-// 	}
-// }
+func TestCloakSetValuesNested(t *testing.T) {
+	state := setSensitiveState([]struct{ name, value string }{
+		{"foo.qux.bar", "42"},
+	})
+	qux := map[string]interface{}{
+		"bar": "bar",
+	}
+	values := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"qux": qux,
+		},
+	}
+	cloakSetValues(values, state)
+	if qux["bar"] != sensitiveContentValue {
+		t.Fatalf("expected %q, got %s", sensitiveContentValue, qux["bar"])
+	}
+}
 
-// func TestCloakSetValuesNested(t *testing.T) {
-// 	d := resourceRelease().Data(nil)
-// 	err := d.Set("set_sensitive", []interface{}{
-// 		map[string]interface{}{"name": "foo.qux.bar", "value": "42"},
-// 	})
-// 	if err != nil {
-// 		t.Fatalf("error setting values: %v", err)
-// 	}
+func TestCloakSetValuesNotMatching(t *testing.T) {
+	state := setSensitiveState([]struct{ name, value string }{
+		{"foo.qux.bar", "42"},
+	})
+	values := map[string]interface{}{
+		"foo": "42",
+	}
+	cloakSetValues(values, state)
+	if values["foo"] != "42" {
+		t.Fatalf("expected %q to be unchanged, got %s", "42", values["foo"])
+	}
+}
 
-// 	qux := map[string]interface{}{
-// 		"bar": "bar",
-// 	}
+func TestDeepCloneMap(t *testing.T) {
+	original := map[string]interface{}{
+		"top": "value",
+		"nested": map[string]interface{}{
+			"inner": "original",
+		},
+	}
+	clone := deepCloneMap(original)
 
-// 	values := map[string]interface{}{
-// 		"foo": map[string]interface{}{
-// 			"qux": qux,
-// 		},
-// 	}
+	// Mutate the clone's nested map
+	clone["nested"].(map[string]interface{})["inner"] = "mutated"
+	clone["top"] = "changed"
 
-// 	cloakSetValues(values, d)
-// 	if qux["bar"] != sensitiveContentValue {
-// 		t.Fatalf("error cloak values, expected %q, got %s", sensitiveContentValue, qux["bar"])
-// 	}
-// }
+	// Original must be untouched
+	if original["top"] != "value" {
+		t.Fatalf("deepCloneMap mutated original top-level key")
+	}
+	if original["nested"].(map[string]interface{})["inner"] != "original" {
+		t.Fatalf("deepCloneMap mutated original nested key")
+	}
+}
 
-// func TestCloakSetValuesNotMatching(t *testing.T) {
-// 	d := resourceRelease().Data(nil)
-// 	err := d.Set("set_sensitive", []interface{}{
-// 		map[string]interface{}{"name": "foo.qux.bar", "value": "42"},
-// 	})
-// 	if err != nil {
-// 		t.Fatalf("error setting values: %v", err)
-// 	}
+func TestExtractSensitiveValues(t *testing.T) {
+	state := setSensitiveState([]struct{ name, value string }{
+		{"db.password", "secret1"},
+		{"api.key", "secret2"},
+	})
+	got := extractSensitiveValues(state)
 
-// 	values := map[string]interface{}{
-// 		"foo": "42",
-// 	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sensitive values, got %d", len(got))
+	}
+	for _, key := range []string{"db.password", "api.key"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("expected key %q in sensitive values map", key)
+		}
+	}
+}
 
-// 	cloakSetValues(values, d)
-// 	if values["foo"] != "42" {
-// 		t.Fatalf("error cloak values, expected %q, got %s", "42", values["foo"])
-// 	}
-// }
+// metadataObjectWithValues builds a fwtypes.Object suitable for HelmReleaseModel.Metadata
+// with the given values and notes strings.
+func metadataObjectWithValues(values, notes string) fwtypes.Object {
+	attrTypes := metadataAttrTypes()
+	obj, _ := fwtypes.ObjectValue(attrTypes, map[string]attr.Value{
+		"name":           fwtypes.StringValue("test"),
+		"revision":       fwtypes.Int64Value(1),
+		"namespace":      fwtypes.StringValue("default"),
+		"chart":          fwtypes.StringValue("test-chart"),
+		"version":        fwtypes.StringValue("1.0.0"),
+		"app_version":    fwtypes.StringValue("1.0.0"),
+		"values":         fwtypes.StringValue(values),
+		"first_deployed": fwtypes.Int64Value(0),
+		"last_deployed":  fwtypes.Int64Value(0),
+		"notes":          fwtypes.StringValue(notes),
+	})
+	return obj
+}
+
+func TestStateMetadataNeedsSuppression_values(t *testing.T) {
+	meta := &Meta{Experiments: map[string]bool{"suppress_metadata_values": true}}
+
+	// State holds real values — suppression is needed.
+	state := &HelmReleaseModel{Metadata: metadataObjectWithValues(`{"key":"val"}`, "")}
+	if !stateMetadataNeedsSuppression(state, meta) {
+		t.Fatal("expected stateMetadataNeedsSuppression=true when suppress_metadata_values is on and state.values contains real data")
+	}
+
+	// State already holds the suppressed sentinel "{}" — no further suppression needed.
+	state2 := &HelmReleaseModel{Metadata: metadataObjectWithValues("{}", "")}
+	if stateMetadataNeedsSuppression(state2, meta) {
+		t.Fatal("expected stateMetadataNeedsSuppression=false when suppress_metadata_values is on and state.values is already \"{}\"")
+	}
+
+	// Experiment disabled — never needs suppression.
+	metaOff := &Meta{Experiments: map[string]bool{}}
+	if stateMetadataNeedsSuppression(state, metaOff) {
+		t.Fatal("expected stateMetadataNeedsSuppression=false when suppress_metadata_values experiment is off")
+	}
+}
+
+func TestStateMetadataNeedsSuppression_notes(t *testing.T) {
+	meta := &Meta{Experiments: map[string]bool{"suppress_metadata_notes": true}}
+
+	// State holds real notes — suppression is needed.
+	state := &HelmReleaseModel{Metadata: metadataObjectWithValues("{}", "some notes")}
+	if !stateMetadataNeedsSuppression(state, meta) {
+		t.Fatal("expected stateMetadataNeedsSuppression=true when suppress_metadata_notes is on and state.notes is populated")
+	}
+
+	// State already holds suppressed notes ("") — no further suppression needed.
+	state2 := &HelmReleaseModel{Metadata: metadataObjectWithValues("{}", "")}
+	if stateMetadataNeedsSuppression(state2, meta) {
+		t.Fatal("expected stateMetadataNeedsSuppression=false when suppress_metadata_notes is on and state.notes is already empty")
+	}
+
+	// Experiment disabled — never needs suppression.
+	metaOff := &Meta{Experiments: map[string]bool{}}
+	if stateMetadataNeedsSuppression(state, metaOff) {
+		t.Fatal("expected stateMetadataNeedsSuppression=false when suppress_metadata_notes experiment is off")
+	}
+}
 
 func testAccHelmReleaseConfigRepositoryURL(resource, ns, name string) string {
 	return fmt.Sprintf(`

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -124,3 +124,15 @@ The `registry` block has options:
 The provider takes an `experiments` block that allows you enable experimental features by setting them to `true`.
 
 * `manifest` - Enable storing of the rendered manifest for `helm_release` so the full diff of what is changing can been seen in the plan.
+* `suppress_metadata_notes` - Suppress verbose helm chart notes from `metadata` output to reduce plan verbosity and avoid exposing potentially sensitive information in logs.
+* `suppress_metadata_values` - Suppress helm values from `metadata` output to reduce plan verbosity and avoid exposing sensitive configuration values in logs.
+
+```terraform
+provider "helm" {
+  experiments = {
+    manifest                 = true
+    suppress_metadata_notes  = true
+    suppress_metadata_values = true
+  }
+}
+```


### PR DESCRIPTION
## Summary

### Problems fixed
1. `metadata.values` emitted `""` when `suppress_metadata_values` is enabled — not valid JSON, breaks `jsondecode()`. Fixed to emit `"{}"`.
2. Infinite recompute loop — `stateMetadataNeedsSuppression` treated `"{}"` as populated. Fixed by treating `"{}"` as the suppressed sentinel.
3. Doc template out of sync — new experiment bullets were in `docs/index.md` but not in `templates/index.md.tmpl`. Fixed.
4. Missing unit tests — rewrote 3 commented-out `TestCloakSetValues*` tests and added `TestDeepCloneMap`, `TestExtractSensitiveValues`, `TestStateMetadataNeedsSuppression_*`.