### PR TITLE
Fix/set sensitive escaped dots (fixes #737 #1788)

### DIFF
--- a/helm/data_helm_template.go
+++ b/helm/data_helm_template.go
@@ -1115,7 +1115,7 @@ func cloakSetValuesModel(config map[string]interface{}, state *HelmTemplateModel
 const sensitiveContentModelValue = "(sensitive value)"
 
 func cloakSetValueModel(values map[string]interface{}, valuePath string) {
-	pathKeys := strings.Split(valuePath, ".")
+	pathKeys := splitKeyPath(valuePath)
 	sensitiveKey := pathKeys[len(pathKeys)-1]
 	parentPathKeys := pathKeys[:len(pathKeys)-1]
 

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -705,7 +705,7 @@ func (r *HelmRelease) Configure(ctx context.Context, req resource.ConfigureReque
 const sensitiveContentValue = "(sensitive value)"
 
 func cloakSetValue(values map[string]interface{}, valuePath string) {
-	pathKeys := strings.Split(valuePath, ".")
+	pathKeys := splitKeyPath(valuePath)
 	sensitiveKey := pathKeys[len(pathKeys)-1]
 	parentPathKeys := pathKeys[:len(pathKeys)-1]
 	m := values

--- a/helm/strvals_helpers.go
+++ b/helm/strvals_helpers.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helm
+
+import "strings"
+
+// splitKeyPath splits a Helm-style value path into key segments,
+// respecting backslash-escaped dots (\.) as literal dots within a key.
+// This matches the escaping convention used by Helm's strvals package.
+//
+// Examples:
+//
+//	splitKeyPath("server.config")          => ["server", "config"]
+//	splitKeyPath("server.oidc\\.config")   => ["server", "oidc.config"]
+//	splitKeyPath("a\\.b\\.c")              => ["a.b.c"]
+//	splitKeyPath("simple")                 => ["simple"]
+func splitKeyPath(path string) []string {
+	var segments []string
+	var current strings.Builder
+
+	i := 0
+	for i < len(path) {
+		if path[i] == '\\' && i+1 < len(path) && path[i+1] == '.' {
+			// Escaped dot: write literal dot, skip both characters
+			current.WriteByte('.')
+			i += 2
+		} else if path[i] == '.' {
+			// Unescaped dot: segment boundary
+			segments = append(segments, current.String())
+			current.Reset()
+			i++
+		} else {
+			current.WriteByte(path[i])
+			i++
+		}
+	}
+	segments = append(segments, current.String())
+
+	return segments
+}

--- a/helm/strvals_helpers_test.go
+++ b/helm/strvals_helpers_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitKeyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple single key",
+			input:    "simple",
+			expected: []string{"simple"},
+		},
+		{
+			name:     "dotted path",
+			input:    "a.b.c",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "single escaped dot",
+			input:    `a\.b`,
+			expected: []string{"a.b"},
+		},
+		{
+			name:     "mixed escaped and unescaped dots",
+			input:    `server.config.oidc\.config`,
+			expected: []string{"server", "config", "oidc.config"},
+		},
+		{
+			name:     "all dots escaped",
+			input:    `a\.b\.c`,
+			expected: []string{"a.b.c"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{""},
+		},
+		{
+			name:     "trailing dot",
+			input:    "a.",
+			expected: []string{"a", ""},
+		},
+		{
+			name:     "leading dot",
+			input:    ".a",
+			expected: []string{"", "a"},
+		},
+		{
+			name:     "multiple escaped dots no unescaped",
+			input:    `no\.dots\.here`,
+			expected: []string{"no.dots.here"},
+		},
+		{
+			name:     "backslash not before dot",
+			input:    `a\b.c`,
+			expected: []string{`a\b`, "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitKeyPath(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("splitKeyPath(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCloakSetValue_EscapedDot(t *testing.T) {
+	values := map[string]interface{}{
+		"server": map[string]interface{}{
+			"config": map[string]interface{}{
+				"oidc.config": "my-secret",
+			},
+		},
+	}
+
+	cloakSetValue(values, `server.config.oidc\.config`)
+
+	got := values["server"].(map[string]interface{})["config"].(map[string]interface{})["oidc.config"]
+	if got != sensitiveContentValue {
+		t.Errorf("expected %q, got %q", sensitiveContentValue, got)
+	}
+}
+
+func TestCloakSetValue_NormalDottedPath(t *testing.T) {
+	values := map[string]interface{}{
+		"auth": map[string]interface{}{
+			"password": "secret123",
+		},
+	}
+
+	cloakSetValue(values, "auth.password")
+
+	got := values["auth"].(map[string]interface{})["password"]
+	if got != sensitiveContentValue {
+		t.Errorf("expected %q, got %q", sensitiveContentValue, got)
+	}
+}

--- a/helm/strvals_helpers_test.go
+++ b/helm/strvals_helpers_test.go
@@ -76,34 +76,57 @@ func TestSplitKeyPath(t *testing.T) {
 	}
 }
 
-func TestCloakSetValue_EscapedDot(t *testing.T) {
-	values := map[string]interface{}{
-		"server": map[string]interface{}{
-			"config": map[string]interface{}{
-				"oidc.config": "my-secret",
+func TestCloakSetValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]interface{}
+		key    string
+		get    func(map[string]interface{}) interface{}
+	}{
+		{
+			name:   "plain key",
+			values: map[string]interface{}{"password": "secret"},
+			key:    "password",
+			get:    func(m map[string]interface{}) interface{} { return m["password"] },
+		},
+		{
+			name: "dotted key",
+			values: map[string]interface{}{
+				"auth": map[string]interface{}{"password": "secret"},
+			},
+			key: "auth.password",
+			get: func(m map[string]interface{}) interface{} {
+				return m["auth"].(map[string]interface{})["password"]
+			},
+		},
+		{
+			name:   "escaped-dotted key",
+			values: map[string]interface{}{"foo.bar": "secret"},
+			key:    `foo\.bar`,
+			get:    func(m map[string]interface{}) interface{} { return m["foo.bar"] },
+		},
+		{
+			name: "nested key",
+			values: map[string]interface{}{
+				"server": map[string]interface{}{
+					"config": map[string]interface{}{
+						"oidc.config": "my-secret",
+					},
+				},
+			},
+			key: `server.config.oidc\.config`,
+			get: func(m map[string]interface{}) interface{} {
+				return m["server"].(map[string]interface{})["config"].(map[string]interface{})["oidc.config"]
 			},
 		},
 	}
 
-	cloakSetValue(values, `server.config.oidc\.config`)
-
-	got := values["server"].(map[string]interface{})["config"].(map[string]interface{})["oidc.config"]
-	if got != sensitiveContentValue {
-		t.Errorf("expected %q, got %q", sensitiveContentValue, got)
-	}
-}
-
-func TestCloakSetValue_NormalDottedPath(t *testing.T) {
-	values := map[string]interface{}{
-		"auth": map[string]interface{}{
-			"password": "secret123",
-		},
-	}
-
-	cloakSetValue(values, "auth.password")
-
-	got := values["auth"].(map[string]interface{})["password"]
-	if got != sensitiveContentValue {
-		t.Errorf("expected %q, got %q", sensitiveContentValue, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloakSetValue(tt.values, tt.key)
+			if got := tt.get(tt.values); got != sensitiveContentValue {
+				t.Errorf("key %q: expected %q, got %q", tt.key, sensitiveContentValue, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

`set_sensitive` values were **not being redacted** in Terraform plan/state
output when the key contained an escaped dot (e.g. `foo\.bar`).

This is a security bug — secrets passed via `set_sensitive` with escaped-dot
keys appeared in plaintext in `terraform plan`, `terraform apply` output, and
stored state.

### Reproducer

```hcl
set_sensitive = [
  {
    name  = "foo\\.bar"
    value = "my-secret"
  }
]

## Root Cause

\`cloakSetValue()\` previously used \`strings.Split(path, \".\")\` to parse the key path.
A key like \`foo\\.bar\` was incorrectly split into \[\`foo\\\`, \`bar\`\] so the walk
silently failed and the real secret value remained visible in state.

## Fix

- Added \`splitKeyPath()\` in \`helm/strvals_helpers.go\` — correctly treats \`\\.\`
  as a literal dot within a key name, not a path separator.
- Updated \`cloakSetValue()\` in \`resource_helm_release.go\` to use \`splitKeyPath()\`.
- Updated \`cloakSetValueModel()\` in \`data_helm_template.go\` to use \`splitKeyPath()\`
  (same bug existed for the \`helm_template\` data source).

## Tests

- \`TestSplitKeyPath\` — table-driven, 10 cases covering all escaping edge cases.
- \`TestCloakSetValue\` — table-driven, 4 cases: plain key, dotted key,
  escaped-dotted key, and nested key.

Fixes #737
Fixes #1788"