### PR TITLE
resource/helm_release: don't skip the uninstall when the release lookup fails

### DIFF
--- a/.changelog/1867.txt
+++ b/.changelog/1867.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/helm_release`: Fix `Delete` skipping the uninstall and dropping the resource from state when the release lookup fails because of a transient error (for example `net/http: TLS handshake timeout`), leaving the release behind in the cluster.
+```

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1251,12 +1251,18 @@ func (r *HelmRelease) Delete(ctx context.Context, req resource.DeleteRequest, re
 	name := state.Name.ValueString()
 	namespace := state.Namespace.ValueString()
 
+	// resourceReleaseExists reports false both when the release is gone and
+	// when the lookup itself failed, so the diagnostics have to be checked
+	// before treating the release as already uninstalled. Otherwise a
+	// transient error talking to the cluster ends the delete right here: the
+	// resource is dropped from state without the uninstall ever running, and
+	// the release stays behind in the cluster.
 	exists, diags := resourceReleaseExists(ctx, name, namespace, meta)
-	if !exists {
-		return
-	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !exists {
 		return
 	}
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`resourceReleaseExists` returns `false` in two very different situations: the release really is gone, and the lookup against the cluster failed. The two are only distinguishable through the diagnostics it returns alongside the boolean.

`Delete` acts on the boolean *before* appending those diagnostics, so the error is discarded:

```go
exists, diags := resourceReleaseExists(ctx, name, namespace, meta)
if !exists {
	return
}
resp.Diagnostics.Append(diags...)   // never reached in the error case
```

A failed lookup is therefore treated as "already uninstalled". `Delete` returns without an error, the framework removes the resource from state, and the uninstall never runs — the release is left behind in the cluster with nothing tracking it any more. Recovering means importing it again or cleaning up with `helm` by hand.

We ran into the underlying failure on AKS during a brief API server outage: the same hiccup surfaced in the `kubernetes` provider as

```
Error: Invalid configuration for API client
Get "https://…azmk8s.io:443/apis": net/http: TLS handshake timeout
```

which was retried and succeeded, while the `helm` provider swallowed it. It hit us on the `Read` path rather than `Delete` (a release was dropped from state and the next apply failed with `cannot re-use a name that is still in use`), but `Delete` has the same ordering and a worse outcome, since the release is not just untracked but silently left running.

This moves the diagnostics check ahead of the `exists` check, so a failed lookup surfaces as an error instead of being interpreted as absence. `Create` already handles it in this order.

**Scope**: the identical ordering issue in `Read` is already addressed in #1734, so this PR deliberately leaves `Read` alone to avoid a conflicting change. #1734 does not touch `Delete`; the two are complementary and can merge in either order.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

No acceptance test: reproducing this requires the API server lookup to fail at a specific point during destroy, which the existing test harness has no hook for. Happy to add one if a maintainer can point at a suitable way to inject the failure.

### Release Note

```release-note:bug
`resource/helm_release`: Fix `Delete` skipping the uninstall and dropping the resource from state when the release lookup fails because of a transient error (for example `net/http: TLS handshake timeout`), leaving the release behind in the cluster.
```

### References

- #1734 — fixes the same ordering issue in `Read`
- #1669 — the state-removal reports that led here

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
