### PR TITLE
build: derive default Capabilities.KubeVersion from client-go

### DIFF
--- a/.changelog/1868.txt
+++ b/.changelog/1868.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`data-source/helm_template`: Default `Capabilities.KubeVersion` to the Kubernetes version the provider is built against instead of `v1.20.0`, so charts declaring a `kubeVersion` constraint render without having to set `kube_version` explicitly.
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,11 +132,22 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |
+            # Derive Helm's default Capabilities.KubeVersion from the
+            # k8s.io/client-go version this provider builds against, mirroring
+            # Helm's own Makefile. Without these, chartutil keeps its in-source
+            # values of 1 and 20, so anything rendering a chart without a
+            # cluster connection reports Kubernetes v1.20.0 and charts declaring
+            # a kubeVersion constraint refuse to render. client-go v0.x.y
+            # corresponds to Kubernetes v1.x.y, hence the +1.
+            K8S_MODULES_VER="$(go list -f '{{.Version}}' -m k8s.io/client-go)"
+            K8S_MODULES_VER="${K8S_MODULES_VER#v}"
+            K8S_MODULES_MAJOR_VER="$(( $(echo "$K8S_MODULES_VER" | cut -d. -f1) + 1 ))"
+            K8S_MODULES_MINOR_VER="$(echo "$K8S_MODULES_VER" | cut -d. -f2)"
             go build \
               -o "$BIN_PATH" \
               -trimpath \
               -buildvcs=false \
-              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
+              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}' -X 'helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=$K8S_MODULES_MAJOR_VER' -X 'helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=$K8S_MODULES_MINOR_VER'"
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
 
   whats-next:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,10 +20,23 @@ endif
 LAST_RELEASE?=$$(git describe --tags $$(git rev-list --tags --max-count=1))
 THIS_RELEASE?=$$(git rev-parse --abbrev-ref HEAD)
 
+# Derive Helm's default Capabilities.KubeVersion from the k8s.io/client-go
+# version this provider builds against, mirroring Helm's own Makefile. Without
+# these, chartutil.k8sVersionMajor/Minor keep their in-source values of 1 and
+# 20, so anything rendering a chart without a cluster connection reports
+# Kubernetes v1.20.0 and charts declaring a kubeVersion constraint refuse to
+# render. client-go v0.x.y corresponds to Kubernetes v1.x.y, hence the +1.
+K8S_MODULES_VER=$(subst ., ,$(subst v,,$(shell go list -f '{{.Version}}' -m k8s.io/client-go)))
+K8S_MODULES_MAJOR_VER=$(shell echo $$(($(firstword $(K8S_MODULES_VER)) + 1)))
+K8S_MODULES_MINOR_VER=$(word 2,$(K8S_MODULES_VER))
+
+LDFLAGS += -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
+LDFLAGS += -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
+
 default: build
 
 build: fmtcheck
-	go build -v .
+	go build -v -ldflags "$(LDFLAGS)" .
 
 # expected to be invoked by make changelog LAST_RELEASE=gitref THIS_RELEASE=gitref
 changelog:
@@ -89,7 +102,7 @@ packages:
 		for arch in $(PKG_ARCH); do \
 			mkdir -p $(BUILD_PATH)/$(PROVIDER)_$${os}_$${arch} && \
 			cd $(BASE_PATH) && \
-			CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} go build -o $(BUILD_PATH)/$(PROVIDER)_$${os}_$${arch}/$(PROVIDER)_$(VERSION) . && \
+			CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} go build -ldflags "$(LDFLAGS)" -o $(BUILD_PATH)/$(PROVIDER)_$${os}_$${arch}/$(PROVIDER)_$(VERSION) . && \
 			cd $(BUILD_PATH) && \
 			tar -cvzf $(BUILD_PATH)/$(PROVIDER)_$(BRANCH)_$${os}_$${arch}.tar.gz $(PROVIDER)_$${os}_$${arch}/; \
 		done; \


### PR DESCRIPTION
### Description

`data.helm_template` reports the rendering cluster as **Kubernetes v1.20.0**, so any chart declaring a `kubeVersion` constraint above 1.20 cannot be rendered at all.

The cause is a missing pair of linker flags rather than anything in the provider's Go code.

Helm's [`pkg/chartutil/capabilities.go`](https://github.com/helm/helm/blob/v3.20.2/pkg/chartutil/capabilities.go#L31-L49) declares the default as build-time overridable variables, with deliberately stale in-source values:

```go
// The Kubernetes version can be set by LDFLAGS. In order to do that the value
// must be a string.
k8sVersionMajor = "1"
k8sVersionMinor = "20"
```

Helm's own [`Makefile`](https://github.com/helm/helm/blob/v3.20.2/Makefile#L60-L69) replaces both at link time, deriving them from the `k8s.io/client-go` version it builds against:

```make
K8S_MODULES_VER=$(subst ., ,$(subst v,,$(shell go list -f '{{.Version}}' -m k8s.io/client-go)))
K8S_MODULES_MAJOR_VER=$(shell echo $$(($(firstword $(K8S_MODULES_VER)) + 1)))
K8S_MODULES_MINOR_VER=$(word 2,$(K8S_MODULES_VER))

LDFLAGS += -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=$(K8S_MODULES_MAJOR_VER)
LDFLAGS += -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=$(K8S_MODULES_MINOR_VER)
```

This provider sets no such flags in either build path, so it links the library with the literal source values and `chartutil.DefaultCapabilities.KubeVersion` resolves to `v1.20.0`. `data.helm_template` sets `ClientOnly` (unless `validate = true`), which is exactly the path that falls back to `DefaultCapabilities` — so every offline render claims v1.20.0.

The resulting error points at the wrong thing. It names a Kubernetes version that exists nowhere in the user's infrastructure, which makes it read as a cluster or chart problem:

```text
Error: Error running Helm install

  with data.helm_template.crds,
  on main.tf line 4, in data "helm_template" "crds":
   4: data "helm_template" "crds" {

Error running Helm install: chart requires kubeVersion: >=1.29.0-0 which is
incompatible with Kubernetes v1.20.0
```

The same chart renders fine with `helm template`, because the CLI is the one build where the flags are set. That divergence is what makes this hard to diagnose from the outside — see #1253, where a user hit this on EKS 1.27, was advised to try installing with `helm` (which works, for this reason), and the report was eventually closed by the stale bot with the cause never identified.

### Fix

Set the two flags in both build paths, mirroring Helm's Makefile:

- **`.github/workflows/build.yml`** — the release build via `hashicorp/actions-go-build`. This is the one that determines what registry users get.
- **`GNUmakefile`** — `build` and `packages`, so local and cross builds behave like released ones. Introduces an `LDFLAGS` variable, as there was none.

`k8s.io/client-go v0.x.y` corresponds to Kubernetes `v1.x.y`, hence the `+1` on the major. With the currently pinned `k8s.io/client-go v0.35.1` the default becomes **v1.35.0**, and it will track the dependency automatically from here on rather than needing a manual bump.

### Verification

Default capability, before and after, linking the same tree:

```console
$ go run ./probe                       # DefaultCapabilities.KubeVersion
v1.20.0
$ go run -ldflags "-X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=1 \
                   -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=35" ./probe
v1.35.0
```

Both build paths resolve the values correctly:

```console
$ make -n build | grep 'go build'
go build -v -ldflags "-X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=1 -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=35" .

$ # workflow derivation, run standalone
$ go list -f '{{.Version}}' -m k8s.io/client-go
v0.35.1
$ echo "major=$K8S_MODULES_MAJOR_VER minor=$K8S_MODULES_MINOR_VER"
major=1 minor=35
```

End to end against a real chart with a `kubeVersion` floor (`cloudnative-pg` declares `kubeVersion: ">=1.29.0-0"`), using this exact config with **no `kube_version` argument**:

```hcl
data "helm_template" "crds" {
  name       = "cnpg-crds"
  namespace  = "cnpg-system"
  repository = "oci://ghcr.io/cloudnative-pg/charts"
  chart      = "cloudnative-pg"
  version    = "0.29.0"
  show_only  = ["templates/crds/crds.yaml"]
  values     = [yamlencode({ crds = { create = true } })]
}
```

| Provider | Result |
| --- | --- |
| released 3.2.0 | `Error running Helm install: chart requires kubeVersion: >=1.29.0-0 which is incompatible with Kubernetes v1.20.0` |
| this branch (`dev_overrides`) | `Read complete after 1s` — all 11 CRDs rendered |

### Notes

- **Not a replacement for `kube_version`.** That argument (added in #985, requested in #917 and #994) stays the way to pin a specific version deliberately. This only makes the *default* current instead of leaving it at Kubernetes 1.20, released December 2020.
- **`validate = true` is not an alternative.** It clears `ClientOnly` so Helm discovers real capabilities, but that makes an offline render require cluster connectivity and adds server-side validation of the whole rendered output.
- **Reproducibility is preserved.** The values derive deterministically from `go.mod`, so `reproducible: report` is unaffected.
- Only the build configuration changes; no Go code and no provider schema is touched, so there is nothing to regenerate in `docs/`.

Relates to #1253, which reported this symptom and was closed without the cause being found.
