### PR TITLE
Error instead of silently truncating split set values

### DIFF
--- a/.changelog/1869.txt
+++ b/.changelog/1869.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/helm_release`: Report an error instead of silently truncating a `set`, `set_sensitive` or `set_list` value that helm's value parser would split on an unescaped comma.
+```
+
+```release-note:bug
+`resource/helm_release`: Stop `set_sensitive` and `set_wo` values from being printed in plan output when parsing them fails, and from being written to debug logs.
+```

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -1420,7 +1420,8 @@ func getWriteOnlyValues(ctx context.Context, model *HelmReleaseModel) (map[strin
 			return nil, diags
 		}
 		for _, set := range setvals {
-			setDiags := getValue(base, set)
+			// Write-only values are secrets by construction.
+			setDiags := getValue(base, set, true)
 			diags.Append(setDiags...)
 			if diags.HasError() {
 				return nil, diags
@@ -1473,7 +1474,7 @@ func getValues(ctx context.Context, model *HelmReleaseModel) (map[string]interfa
 
 		for i, set := range setList {
 			tflog.Debug(ctx, fmt.Sprintf("Processing Set element at index %d: %v", i, set))
-			setDiags := getValue(base, set)
+			setDiags := getValue(base, set, false)
 			diags.Append(setDiags...)
 			if diags.HasError() {
 				tflog.Debug(ctx, fmt.Sprintf("Error occurred while processing Set element at index %d", i))
@@ -1516,8 +1517,9 @@ func getValues(ctx context.Context, model *HelmReleaseModel) (map[string]interfa
 		}
 
 		for i, setSensitive := range setSensitiveList {
-			tflog.Debug(ctx, fmt.Sprintf("Processing Set_Sensitive element at index %d: %v", i, setSensitive))
-			setSensitiveDiags := getValue(base, setSensitive)
+			// Logged by name only: %v on the model renders the value, which is the secret.
+			tflog.Debug(ctx, fmt.Sprintf("Processing Set_Sensitive element at index %d: %s", i, setSensitive.Name))
+			setSensitiveDiags := getValue(base, setSensitive, true)
 			diags.Append(setSensitiveDiags...)
 			if diags.HasError() {
 				tflog.Debug(ctx, fmt.Sprintf("Error occurred while processing Set_Sensitive element at index %d", i))
@@ -1537,7 +1539,128 @@ func getValues(ctx context.Context, model *HelmReleaseModel) (map[string]interfa
 	return base, diags
 }
 
-func getValue(base map[string]interface{}, set setResourceModel) diag.Diagnostics {
+// checkValueIsNotSplit reports whether a single set entry would be parsed as more than one
+// assignment. helm's strvals parser treats "," as an assignment separator, so a value containing an
+// unescaped comma is split: the key keeps only the text before it and the remainder becomes further
+// assignments. When that remainder happens to contain an "=" -- a PEM bundle, a base64 blob, a
+// comment header -- it parses cleanly, so the release is applied with a truncated value and helm
+// exits 0. Nothing in the plan or the apply output shows that anything was dropped.
+//
+// A single entry is expected to produce exactly one leaf. Brace list syntax ("{a,b}") still counts
+// as one leaf, so that stays supported; a split value produces two or more, which is reported here
+// instead of being silently accepted.
+//
+// The diagnostic deliberately does not include the value: this runs for set_sensitive too.
+func checkValueIsNotSplit(name, value string, asString bool) *diag.ErrorDiagnostic {
+	probe := map[string]interface{}{}
+	assignment := fmt.Sprintf("%s=%s", name, value)
+
+	var err error
+	if asString {
+		err = strvals.ParseIntoString(assignment, probe)
+	} else {
+		err = strvals.ParseInto(assignment, probe)
+	}
+	if err != nil {
+		// Left to the real parse below, which reports it.
+		return nil
+	}
+
+	if countLeaves(probe) <= 1 {
+		return nil
+	}
+
+	d := diag.NewErrorDiagnostic(
+		"Value would be truncated",
+		fmt.Sprintf("The value for %q contains an unescaped %q, which helm's value parser treats as a "+
+			"separator between assignments. Only the text before it would reach the chart, and the "+
+			"remainder would be applied as unrelated keys.\n\n"+
+			"Escape it as %q to pass it through unchanged, or supply the value through the `values` "+
+			"attribute instead, which is parsed as YAML and needs no escaping.", name, ",", `\,`),
+	)
+	return &d
+}
+
+// checkListIsNotSplit reports whether a set_list entry would gain elements. The elements are joined
+// with "," into helm's list syntax, so an element containing an unescaped comma silently becomes two
+// elements rather than one.
+//
+// The diagnostic deliberately does not include the elements, which may be sensitive.
+func checkListIsNotSplit(name string, elements []string) *diag.ErrorDiagnostic {
+	// An empty list parses as a single empty element, which is pre-existing behaviour and not a
+	// split, so there is nothing to compare against.
+	if len(elements) == 0 {
+		return nil
+	}
+
+	probe := map[string]interface{}{}
+	if err := strvals.ParseInto(fmt.Sprintf("%s={%s}", name, strings.Join(elements, ",")), probe); err != nil {
+		// Left to the real parse below, which reports it.
+		return nil
+	}
+
+	parsed, ok := lookupPath(probe, name).([]interface{})
+	if !ok || len(parsed) == len(elements) {
+		return nil
+	}
+
+	d := diag.NewErrorDiagnostic(
+		"List value would gain elements",
+		fmt.Sprintf("The list for %q parses as %d elements rather than the %d supplied, because an "+
+			"element contains an unescaped %q, which helm's value parser treats as an element "+
+			"separator.\n\nEscape it as %q to keep the element intact, or supply the list through the "+
+			"`values` attribute instead, which is parsed as YAML and needs no escaping.",
+			name, len(parsed), len(elements), ",", `\,`),
+	)
+	return &d
+}
+
+// lookupPath resolves a dotted strvals key against a parsed result, returning nil if any segment is
+// missing. Keys containing escaped separators are not resolved, which only costs a check.
+func lookupPath(m map[string]interface{}, path string) interface{} {
+	segments := strings.Split(path, ".")
+	var current interface{} = m
+	for _, segment := range segments {
+		asMap, ok := current.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		current, ok = asMap[segment]
+		if !ok {
+			return nil
+		}
+	}
+	return current
+}
+
+// countLeaves counts the non-map values in a parsed strvals result.
+func countLeaves(m map[string]interface{}) int {
+	n := 0
+	for _, v := range m {
+		if child, ok := v.(map[string]interface{}); ok {
+			n += countLeaves(child)
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// parseErrorDetail formats a parse failure. The underlying parser errors quote the fragment they
+// choked on, which for a sensitive entry is part of the secret, so they are withheld there and the
+// escaping hint given instead. Diagnostics are shown in plan output, so this is the difference
+// between a secret being printed and not.
+func parseErrorDetail(name string, err error, sensitive bool) string {
+	if sensitive {
+		return fmt.Sprintf("Failed parsing key %q. The parser error is withheld because the value is "+
+			"sensitive. It is usually an unescaped %q, which helm's value parser treats as a separator "+
+			"between assignments; escape it as %q, or supply the value through the `values` attribute "+
+			"instead, which is parsed as YAML and needs no escaping.", name, ",", `\,`)
+	}
+	return fmt.Sprintf("Failed parsing key %q: %s", name, err)
+}
+
+func getValue(base map[string]interface{}, set setResourceModel, sensitive bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	name := set.Name.ValueString()
@@ -1546,19 +1669,27 @@ func getValue(base map[string]interface{}, set setResourceModel) diag.Diagnostic
 
 	switch valueType {
 	case "auto", "":
+		if d := checkValueIsNotSplit(name, value, false); d != nil {
+			diags.Append(d)
+			return diags
+		}
 		if err := strvals.ParseInto(fmt.Sprintf("%s=%s", name, value), base); err != nil {
-			diags.AddError("Failed parsing value", fmt.Sprintf("Failed parsing key %q with value %s: %s", name, value, err))
+			diags.AddError("Failed parsing value", parseErrorDetail(name, err, sensitive))
 			return diags
 		}
 	case "string":
+		if d := checkValueIsNotSplit(name, value, true); d != nil {
+			diags.Append(d)
+			return diags
+		}
 		if err := strvals.ParseIntoString(fmt.Sprintf("%s=%s", name, value), base); err != nil {
-			diags.AddError("Failed parsing string value", fmt.Sprintf("Failed parsing key %q with value %s: %s", name, value, err))
+			diags.AddError("Failed parsing string value", parseErrorDetail(name, err, sensitive))
 			return diags
 		}
 	case "literal":
 		var literal interface{}
 		if err := yaml.Unmarshal([]byte(fmt.Sprintf("%s: %s", name, value)), &literal); err != nil {
-			diags.AddError("Failed parsing literal value", fmt.Sprintf("Key %q with literal value %s: %s", name, value, err))
+			diags.AddError("Failed parsing literal value", parseErrorDetail(name, err, sensitive))
 			return diags
 		}
 
@@ -1650,8 +1781,13 @@ func getListValue(ctx context.Context, base map[string]interface{}, set set_list
 	// Join the list into a single string
 	listString := strings.Join(listStringArray, ",")
 
+	if d := checkListIsNotSplit(name, listStringArray); d != nil {
+		diags.Append(d)
+		return diags
+	}
+
 	if err := strvals.ParseInto(fmt.Sprintf("%s={%s}", name, listString), base); err != nil {
-		diags.AddError("Error parsing list value", fmt.Sprintf("Failed parsing key %q with value %s: %s", name, listString, err))
+		diags.AddError("Error parsing list value", fmt.Sprintf("Failed parsing key %q: %s", name, err))
 		return diags
 	}
 

--- a/helm/resource_helm_release_set_split_test.go
+++ b/helm/resource_helm_release_set_split_test.go
@@ -1,0 +1,230 @@
+package helm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// A PEM bundle shaped like the ones distributed as a trust store: comment headers, one of which
+// carries a comma, and base64 bodies whose padding contains "=". The "=" is what makes this case
+// dangerous -- the text after the comma parses as a valid assignment, so strvals returns no error
+// and the caller is handed a truncated value.
+const bundleWithCommaInHeader = `GlobalSign Root CA, R3
+======================
+-----BEGIN CERTIFICATE-----
+MIIBfake+base64/data==
+-----END CERTIFICATE-----
+`
+
+func setEntry(name, value, valueType string) setResourceModel {
+	return setResourceModel{
+		Name:  types.StringValue(name),
+		Value: types.StringValue(value),
+		Type:  types.StringValue(valueType),
+	}
+}
+
+func TestGetValueRejectsSplitValue(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		valueType string
+	}{
+		{"string", "string"},
+		{"auto", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := map[string]interface{}{}
+			diags := getValue(base, setEntry("secrets.ca", bundleWithCommaInHeader, tc.valueType), false)
+
+			if !diags.HasError() {
+				t.Fatalf("expected an error, got none; base parsed to %#v", base)
+			}
+			if len(base) != 0 {
+				t.Errorf("expected nothing to be written on failure, got %#v", base)
+			}
+
+			summary := diags.Errors()[0].Summary()
+			detail := diags.Errors()[0].Detail()
+			if summary != "Value would be truncated" {
+				t.Errorf("unexpected summary %q", summary)
+			}
+			// The value may be a secret, so it must not appear in the diagnostic.
+			if strings.Contains(detail, "MIIBfake") || strings.Contains(summary, "MIIBfake") {
+				t.Errorf("diagnostic leaked the value: %s / %s", summary, detail)
+			}
+		})
+	}
+}
+
+// Without the guard this is the silent failure: strvals returns no error, the key keeps only the
+// text before the comma, and the rest lands as unrelated keys.
+func TestStrvalsSilentlyTruncatesUnescapedComma(t *testing.T) {
+	base := map[string]interface{}{}
+	if d := checkValueIsNotSplit("secrets.ca", bundleWithCommaInHeader, true); d == nil {
+		t.Fatal("guard did not fire on a value that strvals splits")
+	}
+
+	// Demonstrate the behaviour the guard exists to prevent.
+	diags := getValue(base, setEntry("secrets.ca", strings.ReplaceAll(bundleWithCommaInHeader, ",", `\,`), "string"), false)
+	if diags.HasError() {
+		t.Fatalf("escaped value should parse: %v", diags.Errors())
+	}
+	secrets, ok := base["secrets"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected secrets map, got %#v", base)
+	}
+	if got := secrets["ca"]; got != bundleWithCommaInHeader {
+		t.Errorf("escaped value did not round-trip:\n got %q\nwant %q", got, bundleWithCommaInHeader)
+	}
+	if len(base) != 1 || len(secrets) != 1 {
+		t.Errorf("expected exactly one key, got %#v", base)
+	}
+}
+
+func TestGetValueAcceptsValuesThatAreNotSplit(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		key       string
+		value     string
+		valueType string
+		want      interface{}
+	}{
+		{"plain string", "a", "no commas here", "string", "no commas here"},
+		{"escaped comma", "a", `x\,y`, "string", "x,y"},
+		{"nested key", "a.b.c", "v", "string", nil},
+		{"multiline without commas", "a", "line1\nline2", "string", "line1\nline2"},
+		{"equals in value", "a", "key=value", "string", "key=value"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := map[string]interface{}{}
+			diags := getValue(base, setEntry(tc.key, tc.value, tc.valueType), false)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags.Errors())
+			}
+			if tc.want != nil {
+				if got := base[tc.key]; got != tc.want {
+					t.Errorf("got %#v, want %#v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// Brace syntax is how a list is meant to be passed through set, and its commas are internal to the
+// list rather than assignment separators, so it must keep working.
+func TestGetValueAcceptsBraceListSyntax(t *testing.T) {
+	base := map[string]interface{}{}
+	diags := getValue(base, setEntry("a", "{x,y,z}", "string"), false)
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags.Errors())
+	}
+	list, ok := base["a"].([]interface{})
+	if !ok {
+		t.Fatalf("expected a list, got %#v", base["a"])
+	}
+	if len(list) != 3 {
+		t.Errorf("expected 3 elements, got %#v", list)
+	}
+}
+
+func TestCountLeaves(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   map[string]interface{}
+		want int
+	}{
+		{"empty", map[string]interface{}{}, 0},
+		{"one leaf", map[string]interface{}{"a": "b"}, 1},
+		{"nested leaf", map[string]interface{}{"a": map[string]interface{}{"b": "c"}}, 1},
+		{"list counts once", map[string]interface{}{"a": []interface{}{"x", "y"}}, 1},
+		{"two leaves", map[string]interface{}{"a": "b", "c": "d"}, 2},
+		{"nested and sibling", map[string]interface{}{"a": map[string]interface{}{"b": "c"}, "d": "e"}, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countLeaves(tc.in); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckListIsNotSplit(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		key       string
+		elements  []string
+		wantError bool
+	}{
+		{"clean elements", "a", []string{"x", "y"}, false},
+		{"element with comma", "a", []string{"x,y", "z"}, true},
+		{"escaped comma", "a", []string{`x\,y`, "z"}, false},
+		{"nested key", "a.b", []string{"x", "y"}, false},
+		{"single element with comma", "a", []string{"x,y"}, true},
+		{"empty list", "a", []string{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := checkListIsNotSplit(tc.key, tc.elements)
+			if tc.wantError && d == nil {
+				t.Fatal("expected an error, got none")
+			}
+			if !tc.wantError && d != nil {
+				t.Fatalf("unexpected error: %s / %s", d.Summary(), d.Detail())
+			}
+			if d != nil && strings.Contains(d.Detail(), "x,y") {
+				t.Errorf("diagnostic leaked an element: %s", d.Detail())
+			}
+		})
+	}
+}
+
+func TestLookupPath(t *testing.T) {
+	m := map[string]interface{}{"a": map[string]interface{}{"b": []interface{}{"x"}}, "c": "d"}
+	if got := lookupPath(m, "a.b"); len(got.([]interface{})) != 1 {
+		t.Errorf("a.b: got %#v", got)
+	}
+	if got := lookupPath(m, "c"); got != "d" {
+		t.Errorf("c: got %#v", got)
+	}
+	for _, missing := range []string{"a.z", "z", "c.d"} {
+		if got := lookupPath(m, missing); got != nil {
+			t.Errorf("%s: expected nil, got %#v", missing, got)
+		}
+	}
+}
+
+// The parser quotes the fragment it choked on, which for a sensitive entry is part of the secret.
+// Diagnostics are shown in plan output, so that fragment must not reach them.
+func TestGetValueDoesNotLeakSensitiveValueInParseError(t *testing.T) {
+	// The tail after the comma has no "=", so strvals errors rather than parsing it as another
+	// assignment -- the path that surfaces the underlying parser error.
+	const secret = "topsecret, MORE-SECRET-MATERIAL"
+
+	t.Run("sensitive withholds the parser error", func(t *testing.T) {
+		base := map[string]interface{}{}
+		diags := getValue(base, setEntry("secrets.token", secret, "string"), true)
+		if !diags.HasError() {
+			t.Fatal("expected an error")
+		}
+		for _, d := range diags.Errors() {
+			if strings.Contains(d.Detail(), "MORE-SECRET-MATERIAL") || strings.Contains(d.Summary(), "MORE-SECRET-MATERIAL") {
+				t.Errorf("secret material reached the diagnostic: %s / %s", d.Summary(), d.Detail())
+			}
+			if !strings.Contains(d.Detail(), "secrets.token") {
+				t.Errorf("diagnostic should still name the key: %s", d.Detail())
+			}
+		}
+	})
+
+	t.Run("non-sensitive keeps the parser error", func(t *testing.T) {
+		base := map[string]interface{}{}
+		diags := getValue(base, setEntry("a.b", secret, "string"), false)
+		if !diags.HasError() {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(diags.Errors()[0].Detail(), "has no value") {
+			t.Errorf("non-sensitive entries should keep the underlying error: %s", diags.Errors()[0].Detail())
+		}
+	})
+}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Yes, two, both narrowing what reaches user-visible output:

- The parse-failure diagnostics no longer include the failing value. They previously interpolated it verbatim (`Failed parsing key %q with value %s: %s`), so a `set_sensitive` or `set_wo` value was printed in plan output whenever parsing it failed. The underlying parser error is withheld for those entries too, since it quotes the fragment it choked on.
- The `set_sensitive` loop logged its whole element at debug level; `%v` on that model renders the value. It now logs the key name alone.

Non-sensitive entries keep the underlying parser error, which is the more useful diagnostic where nothing is at stake.

### Description

`set`, `set_sensitive` and `set_list` values are parsed by `strvals`, which treats `,` as a separator between assignments. A value containing an unescaped comma is therefore split: the key keeps only the text before it, and the remainder is applied as further, unrelated keys.

There are two outcomes, and only one is visible:

- When the remainder contains no `=`, `strvals` returns `key "…" has no value` and the apply fails. This is how the behaviour is usually noticed, and is the subject of most existing reports.
- **When the remainder does contain an `=`** — a PEM bundle, a base64 blob, a comment header — it parses cleanly. No error is returned. The release is applied with a truncated value plus some junk keys, and `helm` exits 0. Nothing in the plan or the apply output indicates that anything was dropped.

The second case is what this fixes. A CA bundle passed through `set_sensitive` reached the chart as a single certificate, because one of its comment headers contained a comma and the base64 payload after it happened to contain `=`.

#### What changed

A single `set` entry is expected to produce exactly one leaf, and a `set_list` entry as many elements as it was given. Both are now checked against a probe parse before the value is merged into the release config, and a mismatch is reported with the escape that fixes it:

```
Error: Value would be truncated

The value for "secrets.ca" contains an unescaped ",", which helm's value parser
treats as a separator between assignments. Only the text before it would reach
the chart, and the remainder would be applied as unrelated keys.

Escape it as "\," to pass it through unchanged, or supply the value through the
`values` attribute instead, which is parsed as YAML and needs no escaping.
```

Brace list syntax (`{a,b}`) still parses to a single leaf, so passing a list through `set` keeps working, as does an already-escaped `x\,y`. An empty `set_list` is skipped, since `{}` parses as one empty element and that is pre-existing behaviour rather than a split.

The diagnostics deliberately name only the key, never the value or elements, for the reason given under Changes to Security Controls.

#### Compatibility

This is breaking for a configuration that relies on the split — `value = "1,b=2"` under `name = "a"` to set two keys from one entry. Such a configuration does work today, so this is a real break rather than a no-op, but it is not a documented behaviour: the docs describe `name` as the full name of *the* variable and `value` as *its* value, and instruct that `,` be escaped. Nothing in the repository's tests or examples relies on it. The multi-assignment form is also never written by the user — `name` and `value` are supplied separately and the provider joins them — so a second assignment can only arise from a comma inside a value, which is the case this fixes.

Checked against the patterns that are documented, all still accepted: escaped dots in `name`, brace list syntax (`{a,b}`), and an already-escaped `x\,y`.

#### Known gap

A brace-wrapped value containing commas is still parsed as a list rather than a string — `value = "{\"timeout\": \"30s\", \"x\": \"y\"}"` becomes a two-element list. That is unchanged behaviour, not a regression, and this guard does not catch it because a list is a single leaf. Rejecting it would require either refusing brace values, which breaks the documented list syntax, or requiring `type = "string"` to yield a string, which would reject brace lists that configurations may rely on. Left alone deliberately.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?

Unit tests rather than acceptance tests, since the behaviour is entirely in value parsing and needs no cluster:

- both split outcomes, for `type = "string"` and for `auto`
- the escaped form round-tripping unchanged, and nothing being written to the config on failure
- brace list syntax, escaped commas, nested keys, multiline values and values containing `=` all still accepted
- `set_list` gaining elements, and the empty-list edge case
- a `set_sensitive` parse failure keeping the value out of the diagnostic, while a non-sensitive one keeps the parser error

Verified end to end outside the test suite as well, against a real chart driven with `helm`: a 248KB, 146-certificate bundle containing 49 commas and 24 backslashes renders byte-identical when escaped, and the same bundle unescaped reproduces the truncation. Stubbing the guard out makes the new tests fail with the original bug rather than passing vacuously.

### Release Note

```release-note
resource/helm_release: Report an error instead of silently truncating a `set`, `set_sensitive` or `set_list` value that helm's value parser would split on an unescaped comma.
resource/helm_release: Stop `set_sensitive` and `set_wo` values from being printed in plan output when parsing them fails, and from being written to debug logs.
```

### References

Adjacent, none overlapping:

- #1788 / #1866 — `set_sensitive` failing to redact when the **key** contains an escaped dot. Same underlying theme of `strvals` escaping being handled inconsistently, but at the other end of the pipeline: that is redaction of a parsed key path, this is correctness of the value being parsed. #1866 adds `splitKeyPath()`, which `lookupPath()` here should use instead of its own `strings.Split` once that merges — noted in a comment on the function.
- #1221 / #1287 / #1817 — `metadata.values` being non-sensitive, so values-supplied secrets appear in plan output. Also unaddressed here.

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
