### PR TITLE
ci: Fix broken Jira search block PR merges

### DIFF
--- a/.changelog/1872.txt
+++ b/.changelog/1872.txt
@@ -1,0 +1,4 @@
+Internal CI-only change: no user-facing effect on the provider, so no release-note entry.
+Marks the "Jira sync" workflow's Search step as continue-on-error, since upstream
+(tomhjp/gh-action-jira-search) still calls a Jira REST endpoint Atlassian has removed,
+which was otherwise blocking PR merges on unrelated code changes.

--- a/.github/workflows/jira-pr.yml
+++ b/.github/workflows/jira-pr.yml
@@ -75,6 +75,13 @@ jobs:
       - name: Search
         if: github.event.action != 'opened'
         id: search
+        # Upstream (tomhjp/gh-action-jira-search) still calls the deprecated
+        # Jira /rest/api/3/search endpoint, which Atlassian has removed
+        # (HTTP 410). continue-on-error keeps this housekeeping sync from
+        # blocking PR merges until upstream migrates to /rest/api/3/search/jql;
+        # downstream steps already gate on steps.search.outputs.issue, so they
+        # skip cleanly when this step fails without setting it.
+        continue-on-error: true
         uses: tomhjp/gh-action-jira-search@04700b457f317c3e341ce90da5a3ff4ce058f2fa # v0.2.2
         with:
           # cf[10089] is Issue Link (use JIRA API to retrieve)


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, revert this commit - it only changes CI workflow behavior, nothing in the provider binary.

## Changes to Security Controls

None. This is a CI-only workflow change; no provider code, schema, or runtime behavior is affected.

### Description

The `Jira sync` check (`.github/workflows/jira-pr.yml`) fails on every PR event other than `opened` (edits, closes, reopens). Root cause: the `Search` step calls `tomhjp/gh-action-jira-search`, whose `main.go` hardcodes a call to Jira's `GET /rest/api/3/search` endpoint — an endpoint Atlassian has since retired:

```
API call GET /rest/api/3/search failed (410):
"The requested API has been removed. Please migrate to the /rest/api/3/search/jql API."
```


Since this workflow is internal Jira-ticket bookkeeping with no bearing on code correctness, this PR marks the `Search` step `continue-on-error: true` so it stops blocking `mergeStateStatus` on unrelated PRs while upstream remains unfixed. The downstream steps (`Sync comment`, `Close PR`, `Reopen PR`) already gate on `steps.search.outputs.issue`, so when `Search` fails without setting that output, they skip cleanly instead of the job erroring.

Same fix, same root cause, already applied to the sibling `terraform-provider-kubernetes` repo: [hashicorp/terraform-provider-kubernetes#2958](https://github.com/hashicorp/terraform-provider-kubernetes/pull/2958).

Scope note: `.github/workflows/jira-issues.yml` has the identical pattern and will fail the same way, but is intentionally left out of this PR to keep the change scoped to what's actually blocking PR merges — same scoping decision made in the companion k8s-provider fix.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Not applicable — this is a GitHub Actions workflow change, not provider code, so `make testacc` doesn't apply. Verified instead via:

```
$ actionlint .github/workflows/jira-pr.yml
# same pre-existing shellcheck warnings as origin/main (unrelated Set-ticket-type
# script quoting); nothing new introduced by this change

$ act workflow_dispatch -W <synthetic repro workflow> -P ubuntu-latest=catthehacker/ubuntu:act-latest
# reproduced the exact step/output mechanism locally against Docker:
# Search step fails (continue-on-error: true) -> "Failed but continue next step"
# downstream step gated on steps.search.outputs.issue -> skipped cleanly, never runs
# job result -> "Job succeeded"
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/main/CHANGELOG.md):

```release-note
NONE
```
### References

- Same root cause and fix as [hashicorp/terraform-provider-kubernetes#2958](https://github.com/hashicorp/terraform-provider-kubernetes/pull/2958)
- Upstream root cause: [tomhjp/gh-action-jira-search main.go](https://github.com/tomhjp/gh-action-jira-search/blob/main/main.go) hardcodes `/rest/api/3/search`
- Atlassian's deprecation notice: `/rest/api/3/search` removed, migrate to `/rest/api/3/search/jql`

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
